### PR TITLE
fix: add directory coverage guidance from coach signals

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -20,6 +20,21 @@ Generate and maintain AGENTS.md files following the public agents.md convention.
 - Existing projects: Standardize agent documentation
 - Multi-repo consistency: Apply same standards across repositories
 
+## Directory Coverage
+
+Create AGENTS.md in ALL key directories, not just root:
+
+| Directory | Purpose |
+|-----------|---------|
+| Root | Precedence, architecture overview |
+| `Classes/` or `src/` | Source code patterns |
+| `Configuration/` or `config/` | Framework config |
+| `Documentation/` or `docs/` | Doc standards |
+| `Resources/` or `assets/` | Templates, assets |
+| `Tests/` | Testing patterns |
+
+See `references/directory-coverage.md` for full guidance.
+
 ## Commands
 
 ```bash

--- a/references/directory-coverage.md
+++ b/references/directory-coverage.md
@@ -1,0 +1,62 @@
+# Directory Coverage for AGENTS.md
+
+Comprehensive AGENTS.md coverage means creating files in ALL key directories, not just root.
+
+## Why Full Coverage Matters
+
+- Each directory has unique patterns and conventions
+- AI agents working in subdirectories benefit from local context
+- Reduces need to navigate up to root AGENTS.md
+
+## Standard Directory Structure
+
+### PHP/TYPO3 Projects
+
+| Directory | AGENTS.md Content |
+|-----------|-------------------|
+| Root | Project overview, precedence list, architecture diagram |
+| `Classes/` | DI patterns, service layer, security rules |
+| `Configuration/` | TCA, Services.yaml, module registration |
+| `Documentation/` | RST standards, directives, rendering |
+| `Resources/` | Templates, XLIFF, assets |
+| `Tests/` | Unit/functional patterns, fixtures |
+| `Tests/E2E/` | E2E-specific patterns (if exists) |
+
+### Go Projects
+
+| Directory | AGENTS.md Content |
+|-----------|-------------------|
+| Root | Module overview, build commands |
+| `cmd/` | CLI entry points, flags |
+| `internal/` | Private packages, no export |
+| `pkg/` | Public API patterns |
+
+### TypeScript/Node Projects
+
+| Directory | AGENTS.md Content |
+|-----------|-------------------|
+| Root | Package overview, scripts |
+| `src/` | Source patterns, imports |
+| `components/` | UI component patterns |
+| `tests/` or `__tests__/` | Testing patterns |
+
+## Precedence Rules
+
+Root AGENTS.md should list all child files:
+
+```markdown
+## Precedence
+
+1. This file (root)
+2. Directory-specific files:
+   - `Classes/AGENTS.md`
+   - `Configuration/AGENTS.md`
+   - `Tests/AGENTS.md`
+3. Framework standards
+```
+
+## Anti-pattern
+
+**Wrong**: Only creating root AGENTS.md and Tests/AGENTS.md
+
+**Right**: Create AGENTS.md in EVERY directory with unique patterns


### PR DESCRIPTION
Add explicit guidance to create AGENTS.md in ALL key directories. Source: coach signal about directory coverage.