### PR TITLE
fix: add exact name matching and command verification requirements

### DIFF
--- a/skills/agents/SKILL.md
+++ b/skills/agents/SKILL.md
@@ -52,10 +52,43 @@ When checking if AGENTS.md files are up to date, use the freshness checking scri
 |----------|---------------------|
 | Module list | `ls <dir>/*.py` + read docstrings |
 | Script list | `ls scripts/*.sh` + read headers |
-| Commands | `grep` Makefile targets |
+| Commands | `grep` Makefile targets **AND run them** |
 | Test files | `ls tests/*.py` |
 | Data files | `ls *.json` in project root |
 | Config files | Check actual existence |
+| **File names** | **EXACT match required** (not just existence) |
+| **Numeric values** | PHPStan level, coverage %, etc. from actual configs |
+
+### Critical: Exact Name Matching
+
+File names in AGENTS.md must match actual filenames **exactly**:
+
+| Documented | Actual | Status |
+|------------|--------|--------|
+| `CowriterAjaxController.php` | `AjaxController.php` | **WRONG** - name mismatch |
+| `AjaxController.php` | `AjaxController.php` | Correct |
+
+**Real-world example from t3x-cowriter review:**
+- AGENTS.md documented `Controller/CowriterAjaxController.php`
+- Actual file was `Controller/AjaxController.php`
+- This mismatch confused agents trying to find the file
+
+### Critical: Command Verification
+
+Commands documented in AGENTS.md must actually work when run:
+
+```bash
+# BAD: Document without testing
+make test-mutation  # May not exist!
+
+# GOOD: Verify before documenting
+make -n test-mutation 2>/dev/null && echo "EXISTS" || echo "MISSING"
+```
+
+**Real-world example from t3x-cowriter review:**
+- AGENTS.md documented `make test-mutation` and `make phpstan`
+- Neither target existed (actual was `make typecheck`)
+- Agents failed when trying to run documented commands
 
 ### Example Verification Commands
 


### PR DESCRIPTION
## Summary

Adds stricter verification requirements for AGENTS.md accuracy based on learnings from t3x-cowriter comprehensive review.

## Problem Discovered

During t3x-cowriter review, we found AGENTS.md files with:
- **Wrong controller name**: Documented `CowriterAjaxController.php` but actual file was `AjaxController.php`
- **Non-existent make targets**: Documented `make test-mutation` and `make phpstan` but neither existed (actual was `make typecheck`)
- **PHPStan level mismatch**: Root AGENTS.md said level 8, Classes/AGENTS.md said level 10

These mismatches caused agents to fail when trying to use documented information.

## Changes

Added to verification requirements:
- File names must match **exactly**, not just exist
- Numeric values (PHPStan level, coverage %) must come from actual config files
- Commands must be **tested** before documenting (not just grepped)
- Real-world examples showing the problems and correct approach

## Checklist

- [x] Follows skill documentation standards
- [x] Real-world example included
- [x] Actionable verification commands provided