### PR TITLE
feat(templates): add verification rules to AGENTS.md templates

### DIFF
--- a/skills/agents/assets/root-thin.md
+++ b/skills/agents/assets/root-thin.md
@@ -26,7 +26,7 @@
 1. **Before coding**: Read nearest `AGENTS.md` + check Golden Samples for the area you're touching
 2. **After each change**: Run the smallest relevant check (lint → typecheck → single test)
 3. **Before committing**: Run full test suite if changes affect >2 files or touch shared code
-4. **Before claiming done**: Run verification and **show output as evidence** — never say "should work" without proof
+4. **Before claiming done**: Run verification and **show output as evidence** — never say "try again" or "should work now" without proof
 
 ## File Map
 <!-- AGENTS-GENERATED:START filemap -->

--- a/skills/agents/assets/root-verbose.md
+++ b/skills/agents/assets/root-verbose.md
@@ -61,7 +61,7 @@
 1. **Before coding**: Read nearest `AGENTS.md` + check Golden Samples for the area you're touching
 2. **After each change**: Run the smallest relevant check (lint → typecheck → single test)
 3. **Before committing**: Run full test suite if changes affect >2 files or touch shared code
-4. **Before claiming done**: Run verification and **show output as evidence** — never say "should work" without proof
+4. **Before claiming done**: Run verification and **show output as evidence** — never say "try again" or "should work now" without proof
 
 ## Pre-commit Checks
 > Source: {{COMMAND_SOURCE}} — CI-sourced commands are most reliable


### PR DESCRIPTION
## Summary

Add mandatory verification workflow rules to AGENTS.md templates based on friction analysis from real development sessions.

### Changes to both `root-thin.md` and `root-verbose.md`:

**Workflow/Agent Work Loop:**
- Added step 4: "Before claiming done: Run verification and **show output as evidence** — never say 'should work' without proof"

**Boundaries > Always Do:**
- "Show test output as evidence before claiming work is complete — never say 'try again' or 'should work now' without proof"
- "For upstream dependency fixes: run **full** test suite, not just affected tests"

## Why

Friction analysis revealed common agent failure patterns:
- Claiming fixes work without running tests
- Saying "should work now" or "try again" without evidence
- Running only affected tests when verifying upstream fixes (misses regressions)

These rules ensure agents provide evidence-based claims, reducing user frustration.

## Source

Friction analysis from Go development sessions (Feb 2026) - patterns apply universally.