### PR TITLE
fix: add composer extra block and fix plugin.json author URL

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
   "license": "GPL-2.0-or-later",
   "author": {
     "name": "Netresearch DTT GmbH",
-    "url": "https://github.com/netresearch/agents-skill"
+    "url": "https://www.netresearch.de"
   },
   "skills": [
     "./skills/agents"

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,8 @@
   "support": {
     "issues": "https://github.com/netresearch/agents-skill/issues",
     "source": "https://github.com/netresearch/agents-skill"
+  },
+  "extra": {
+    "ai-agent-skill": "skills/agents/SKILL.md"
   }
 }


### PR DESCRIPTION
## Summary
- Clean SKILL.md frontmatter to only name + description (pagerangers)
- Fix description to start with "Use when" (pagerangers)
- Add missing composer.json extra.ai-agent-skill path (agents)
- Standardize plugin.json author.url to company website (agents)

## Context
Per writing-skills standards, SKILL.md frontmatter should only contain `name` and `description`.
Descriptions must start with "Use when" and describe triggering conditions only.