### PR TITLE
fix: reduce false positives in AG-02 and AG-03 checkpoints

### DIFF
--- a/skills/agent-rules/checkpoints.yaml
+++ b/skills/agent-rules/checkpoints.yaml
@@ -17,14 +17,14 @@ mechanical:
   - id: AG-02
     type: regex
     target: AGENTS.md
-    pattern: "^#+ (Overview|Project|About)"
+    pattern: "^#+ (.*Overview|Project|About)"
     severity: warning
     desc: "AGENTS.md should have an Overview/Project section (recommended but not required)"
 
   - id: AG-03
     type: regex
     target: AGENTS.md
-    pattern: "^#+ (Setup|Getting Started|Prerequisites|Dev Environment)"
+    pattern: "^#+ (Setup|Getting Started|Prerequisites|Dev Environment|Development Workflow)"
     severity: warning
     desc: "AGENTS.md should have Setup/Dev Environment section (recommended but not required)"
 


### PR DESCRIPTION
## Summary
- **AG-02**: Pattern `^#+ (Overview|Project|About)` missed headings like "Project Overview". Changed to `^#+ (.*Overview|Project|About)` so any heading ending in "Overview" matches.
- **AG-03**: Pattern now also accepts "Development Workflow" as a valid section heading, alongside "Setup", "Getting Started", etc.

## Test plan
- [ ] Verify AG-02 matches `## Project Overview`, `## Overview`, `## About`
- [ ] Verify AG-03 matches `## Development Workflow`, `## Getting Started`, `## Setup`