### PR TITLE
fix(ci): add explicit workflow-permissions to security.yml jobs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,9 +6,16 @@ on:
   pull_request:
     branches: [main, master]
 
+# Principle of least privilege: top-level grants the minimum every job
+# needs. Jobs that need more expand their own permissions block below.
+permissions:
+  contents: read
+
 jobs:
   gitleaks:
     uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
     secrets:
       GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
@@ -21,3 +28,6 @@ jobs:
 
   composer-audit:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write  # SARIF upload for SAST scan


### PR DESCRIPTION
## Summary

Clears the two open CodeQL alerts (`actions/missing-workflow-permissions`) on `.github/workflows/security.yml` lines 11 and 23 by declaring explicit permissions at the caller level for each reusable-workflow invocation.

## Changes

- **Top-level** \`permissions: contents: read\` — principle of least privilege default
- **\`gitleaks\` job** — explicit \`contents: read\` (checkout only)
- **\`composer-audit\` job** — \`contents: read\` + \`security-events: write\` (for SARIF upload by the reusable SAST workflow)
- **\`dependency-review\`** was already correct; untouched

No runtime behavior change.

## Test plan

- [x] YAML valid
- [x] Minimal scopes aligned with what each reusable workflow documents
- [ ] CodeQL re-scan on merged main should clear both alerts