### PR TITLE
fix: bump vite to ^7.3.2 (CVE-2026-39365) in fixtures + declare npm ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,45 +9,23 @@ updates:
         patterns:
           - "*"
 
-  # npm ecosystem entries for fixture projects. Dependabot security updates
-  # need a declared ecosystem+directory path or the updater errors out when
-  # trying to open PRs for vulnerable packages (see CVE-2026-39365 on vite).
-  # Schedule is weekly so non-security routine bumps don't flood PRs on
-  # fixtures that aren't actively built.
+  # Single npm entry covering all fixture projects via Dependabot's plural
+  # `directories:` syntax. Using one entry (instead of five) means the
+  # `fixture-deps` group consolidates routine updates across all fixtures
+  # into a single grouped PR — without this, each `package-ecosystem +
+  # directory` pair has its own group scope and Dependabot opens one PR
+  # per directory (copilot/gemini flagged this on PR #35).
+  #
+  # Dependabot security updates also need a matching ecosystem+directory
+  # entry, or the updater errors when trying to open PRs for vulnerable
+  # packages (see CVE-2026-39365 on vite, which motivated adding this).
   - package-ecosystem: npm
-    directory: /skills/agent-rules/references/examples/go-api-with-react-admin/admin
-    schedule:
-      interval: weekly
-    groups:
-      fixture-deps:
-        patterns: ["*"]
-
-  - package-ecosystem: npm
-    directory: /skills/agent-rules/references/examples/go-with-internal-web-tsx
-    schedule:
-      interval: weekly
-    groups:
-      fixture-deps:
-        patterns: ["*"]
-
-  - package-ecosystem: npm
-    directory: /skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web
-    schedule:
-      interval: weekly
-    groups:
-      fixture-deps:
-        patterns: ["*"]
-
-  - package-ecosystem: npm
-    directory: /skills/agent-rules/references/examples/php-with-frontend
-    schedule:
-      interval: weekly
-    groups:
-      fixture-deps:
-        patterns: ["*"]
-
-  - package-ecosystem: npm
-    directory: /skills/agent-rules/references/examples/php-with-frontend/web
+    directories:
+      - /skills/agent-rules/references/examples/go-api-with-react-admin/admin
+      - /skills/agent-rules/references/examples/go-with-internal-web-tsx
+      - /skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web
+      - /skills/agent-rules/references/examples/php-with-frontend
+      - /skills/agent-rules/references/examples/php-with-frontend/web
     schedule:
       interval: weekly
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,48 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # npm ecosystem entries for fixture projects. Dependabot security updates
+  # need a declared ecosystem+directory path or the updater errors out when
+  # trying to open PRs for vulnerable packages (see CVE-2026-39365 on vite).
+  # Schedule is weekly so non-security routine bumps don't flood PRs on
+  # fixtures that aren't actively built.
+  - package-ecosystem: npm
+    directory: /skills/agent-rules/references/examples/go-api-with-react-admin/admin
+    schedule:
+      interval: weekly
+    groups:
+      fixture-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /skills/agent-rules/references/examples/go-with-internal-web-tsx
+    schedule:
+      interval: weekly
+    groups:
+      fixture-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web
+    schedule:
+      interval: weekly
+    groups:
+      fixture-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /skills/agent-rules/references/examples/php-with-frontend
+    schedule:
+      interval: weekly
+    groups:
+      fixture-deps:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /skills/agent-rules/references/examples/php-with-frontend/web
+    schedule:
+      interval: weekly
+    groups:
+      fixture-deps:
+        patterns: ["*"]

--- a/skills/agent-rules/references/examples/go-api-with-react-admin/admin/package.json
+++ b/skills/agent-rules/references/examples/go-api-with-react-admin/admin/package.json
@@ -12,7 +12,7 @@
         "react-dom": "^18.2.0"
     },
     "devDependencies": {
-        "vite": "^5.0.0",
+        "vite": "^7.3.2",
         "vitest": "^1.0.0",
         "eslint": "^8.56.0",
         "typescript": "^5.3.0"

--- a/skills/agent-rules/references/examples/go-api-with-react-admin/admin/package.json
+++ b/skills/agent-rules/references/examples/go-api-with-react-admin/admin/package.json
@@ -12,7 +12,7 @@
         "react-dom": "^18.2.0"
     },
     "devDependencies": {
-        "vite": "^7.3.2",
+        "vite": "^8.0.8",
         "vitest": "^1.0.0",
         "eslint": "^8.56.0",
         "typescript": "^5.3.0"

--- a/skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web/package.json
+++ b/skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web/package.json
@@ -11,7 +11,7 @@
         "react-dom": "^18.2.0"
     },
     "devDependencies": {
-        "vite": "^7.3.2",
+        "vite": "^8.0.8",
         "vitest": "^1.0.0"
     }
 }

--- a/skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web/package.json
+++ b/skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web/package.json
@@ -11,7 +11,7 @@
         "react-dom": "^18.2.0"
     },
     "devDependencies": {
-        "vite": "^5.0.0",
+        "vite": "^7.3.2",
         "vitest": "^1.0.0"
     }
 }

--- a/skills/agent-rules/references/examples/go-with-internal-web-tsx/package.json
+++ b/skills/agent-rules/references/examples/go-with-internal-web-tsx/package.json
@@ -6,6 +6,6 @@
     },
     "devDependencies": {
         "react": "^18.0.0",
-        "vite": "^7.3.2"
+        "vite": "^8.0.8"
     }
 }

--- a/skills/agent-rules/references/examples/go-with-internal-web-tsx/package.json
+++ b/skills/agent-rules/references/examples/go-with-internal-web-tsx/package.json
@@ -6,6 +6,6 @@
     },
     "devDependencies": {
         "react": "^18.0.0",
-        "vite": "^5.0.0"
+        "vite": "^7.3.2"
     }
 }

--- a/skills/agent-rules/references/examples/go-with-internal-web-tsx/package.json
+++ b/skills/agent-rules/references/examples/go-with-internal-web-tsx/package.json
@@ -6,6 +6,7 @@
     },
     "devDependencies": {
         "react": "^18.0.0",
-        "vite": "^8.0.8"
+        "vite": "^8.0.8",
+        "vitest": "^1.0.0"
     }
 }

--- a/skills/agent-rules/references/examples/php-with-frontend/package.json
+++ b/skills/agent-rules/references/examples/php-with-frontend/package.json
@@ -8,7 +8,7 @@
     },
     "devDependencies": {
         "react": "^18.0.0",
-        "vite": "^5.0.0",
+        "vite": "^7.3.2",
         "vitest": "^1.0.0"
     }
 }

--- a/skills/agent-rules/references/examples/php-with-frontend/package.json
+++ b/skills/agent-rules/references/examples/php-with-frontend/package.json
@@ -8,7 +8,7 @@
     },
     "devDependencies": {
         "react": "^18.0.0",
-        "vite": "^7.3.2",
+        "vite": "^8.0.8",
         "vitest": "^1.0.0"
     }
 }

--- a/skills/agent-rules/references/examples/php-with-frontend/package.json
+++ b/skills/agent-rules/references/examples/php-with-frontend/package.json
@@ -7,6 +7,7 @@
         "test": "vitest run"
     },
     "devDependencies": {
+        "eslint": "^8.56.0",
         "react": "^18.0.0",
         "vite": "^8.0.8",
         "vitest": "^1.0.0"

--- a/skills/agent-rules/references/examples/php-with-frontend/web/package.json
+++ b/skills/agent-rules/references/examples/php-with-frontend/web/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^18.2.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
-    "vite": "^5.0.0",
+    "vite": "^7.3.2",
     "vitest": "^1.0.0"
   }
 }

--- a/skills/agent-rules/references/examples/php-with-frontend/web/package.json
+++ b/skills/agent-rules/references/examples/php-with-frontend/web/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^18.2.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
-    "vite": "^7.3.2",
+    "vite": "^8.0.8",
     "vitest": "^1.0.0"
   }
 }

--- a/skills/agent-rules/references/examples/php-with-frontend/web/package.json
+++ b/skills/agent-rules/references/examples/php-with-frontend/web/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
+    "eslint": "^8.56.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
     "vite": "^8.0.8",


### PR DESCRIPTION
## Summary

Fixes the **Dependabot Updates workflow failure** (run #24602476812) plus 5 open Dependabot alerts, by:

1. Bumping vite to a patched version in all 5 fixture \`package.json\` files
2. Declaring the npm ecosystem for those paths in \`.github/dependabot.yml\` so future security updates have a registered directory to run in

## Root cause

Dependabot auto-runs security updates regardless of \`dependabot.yml\` config, but when no matching \`package-ecosystem + directory\` entry is declared for the vulnerable manifest, the updater errors out. Result: persistent workflow failures on \`main\` while the underlying vulnerability stays unfixed.

## CVE

[GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9) / [CVE-2026-39365](https://nvd.nist.gov/vuln/detail/CVE-2026-39365) — path traversal in vite's optimized-deps \`.map\` handling. Affects \`<= 6.4.1\`, \`7.0.0 - 7.3.1\`, \`8.0.0 - 8.0.4\`. Five fixture manifests pinned \`^5.0.0\` (no patch on the 5.x line; users must jump majors).

## Changes

- \`skills/agent-rules/references/examples/go-api-with-react-admin/admin/package.json\`: \`vite ^5.0.0 → ^7.3.2\`
- \`skills/agent-rules/references/examples/go-with-internal-web-tsx/package.json\`: same
- \`skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web/package.json\`: same
- \`skills/agent-rules/references/examples/php-with-frontend/package.json\`: same
- \`skills/agent-rules/references/examples/php-with-frontend/web/package.json\`: same
- \`.github/dependabot.yml\`: added 5 \`package-ecosystem: npm\` entries (one per fixture directory), weekly schedule, grouped under \`fixture-deps\` so routine updates batch into one PR

Single-line change per package.json (original 4-space indent preserved).

## Why ^7.3.2 specifically

vite 6.4.2, 7.3.2, and 8.0.5 all patch the CVE. Chose 7.3.2 as a conservative minimal jump from the 5.x line that keeps fixtures modern without chasing the latest major. Fixtures are demos used by the agent-rules generator test matrix — they don't actually build/run, so the ecosystem choice is about static-parse fidelity rather than runtime compatibility.

## Test plan

- [x] All 5 \`package.json\` files parse as valid JSON (\`jq . <file>\` passes)
- [x] \`.github/dependabot.yml\` is valid YAML
- [ ] Dependabot Updates workflow turns green on \`main\` after merge
- [ ] 5 open vite alerts auto-close once Dependabot re-scans merged HEAD