### PR TITLE
fix(checkpoints): AG-13 regex compiles + matches both Commands variants

### DIFF
--- a/skills/agent-rules/checkpoints.yaml
+++ b/skills/agent-rules/checkpoints.yaml
@@ -91,9 +91,9 @@ mechanical:
   - id: AG-13
     type: regex
     target: AGENTS.md
-    pattern: '^#+ Commands( \(verified)?'
+    pattern: '^#+ Commands( \(verified[^)]*\))?'
     severity: warning
-    desc: "AGENTS.md should have Commands section (optionally with '(verified)' suffix for trust scoring)"
+    desc: "AGENTS.md should have Commands section (optionally with '(verified)' or '(verified DATE)' suffix for trust scoring)"
 
   - id: AG-14
     type: regex

--- a/skills/agent-rules/checkpoints.yaml
+++ b/skills/agent-rules/checkpoints.yaml
@@ -91,9 +91,9 @@ mechanical:
   - id: AG-13
     type: regex
     target: AGENTS.md
-    pattern: "^#+ (Commands|Commands \\(verified)"
+    pattern: '^#+ Commands( \(verified)?'
     severity: warning
-    desc: "AGENTS.md should have Commands section with verification status"
+    desc: "AGENTS.md should have Commands section (optionally with '(verified)' suffix for trust scoring)"
 
   - id: AG-14
     type: regex


### PR DESCRIPTION
## Summary

Fixes #40.

The previous AG-13 pattern \`"^#+ (Commands|Commands \\\\(verified)"\` produced \`\\\\(verified\` after YAML double-quote unescape, which grep/ugrep parse as a literal backslash followed by an opening group — leaving the outer group's \`)\` unmatched. ugrep emits \`mismatched (\` and refuses to run, so AG-13 **always** reported "Pattern not found" regardless of AGENTS.md content.

## Change

\`\`\`diff
-    pattern: "^#+ (Commands|Commands \\\\(verified)"
+    pattern: '^#+ Commands( \(verified)?'
\`\`\`

Single-quoted YAML to avoid escape stacking + optional-group syntax. Matches:

- \`## Commands\` ✓
- \`## Commands (verified 2026-04-24)\` ✓
- \`## Setup\` ✗ (correctly negative)

## Test plan

- [ ] CI green
- [x] Manual: verified compiles under grep -E + ugrep, matches both heading forms