### PR TITLE
feat: add feedback-memory-schema for retro-skill integration

### DIFF
--- a/skills/agent-rules/references/feedback-memory-schema.md
+++ b/skills/agent-rules/references/feedback-memory-schema.md
@@ -4,19 +4,30 @@ Canonical format for **approved session learnings** materialized as project-rule
 
 ## When this schema applies
 
-- **user-memory destination:** `retro-skill` writes to `~/.claude/projects/<slug>/memory/feedback_<slug>.md`
-- **project-rule destination:** `retro-skill` writes to `<project>/docs/feedback/<slug>.md`
+| Destination | Path |
+|---|---|
+| **user-memory** (personal preference across projects) | `~/.claude/projects/<project-dir-slug>/memory/feedback_<slug>.md` |
+| **project-rule** (project-specific convention) | `<project>/docs/feedback/feedback_<slug>.md` |
 
-Both files use the same schema. The location indicates the scope.
+### Variable definitions
+
+| Variable | Meaning | Example |
+|---|---|---|
+| `<project-dir-slug>` | Claude Code's encoding of the absolute working directory for user-memory. Slashes are replaced with `-`. | `/home/sme/p` → `-home-sme-p` |
+| `<slug>` | kebab-case filename slug for *this specific learning* | `merge-strategy`, `preserve-commit-signing` |
+
+`<project-dir-slug>` and `<slug>` are distinct. `retro-skill` MUST compute `<project-dir-slug>` deterministically from the absolute working directory at the time of materialization (not from any frontmatter field).
+
+For user-memory **global** scope (not tied to a single project): place under whatever project-dir-slug Claude Code uses for global memory; consult `~/.claude/projects/` for the convention in use.
 
 ## Schema
 
 ```markdown
 ---
-name: <kebab-case-slug>
-description: <one-line summary; used for relevance scoring across sessions>
+name: <human-readable title; may be free prose>
+description: "<one-line summary; used for relevance scoring across sessions>"
 type: feedback
-originSessionId: <session-id-from-jsonl-filename, optional but recommended>
+originSessionId: <session-id-from-jsonl-filename>
 ---
 **Why:** <1-2 paragraphs explaining the friction and root cause>
 
@@ -27,71 +38,98 @@ originSessionId: <session-id-from-jsonl-filename, optional but recommended>
 
 | Field | Required | Notes |
 |---|---|---|
-| `name` | yes | kebab-case slug, used in filename (`feedback_<name>.md`) |
-| `description` | yes | one-line summary, ≤200 chars; used by retro-skill to score relevance against new friction |
-| `type` | yes | always `feedback` (distinguishes from other memory types) |
-| `originSessionId` | recommended | Session ID where the friction was first observed (audit trail) |
-| `**Why:** …` | yes | Root cause analysis. Without this, the file rots — readers can't judge if it still applies. |
-| `**How to apply:** …` | yes | Concrete action for the agent. Vague rules don't change behavior. |
+| `name` | yes | Human-readable title for the learning. May be a free-form sentence (e.g. `"Preserve commit signing on rewrite operations"`) or a short slug (e.g. `"merge strategy"`). **Not necessarily kebab-case** — the canonical examples use both natural language and slugs. The **filename** uses an independent kebab-case slug (see "Filename slug" below). |
+| `description` | yes | One-line summary, ≤200 chars. Used by retro-skill to score relevance against new friction. **MUST be double-quoted** when it contains any of `: # [ ] { } , & * ! \| > ' " % @` or a leading whitespace, or it may break YAML parsing. Safer rule: quote unconditionally. |
+| `type` | yes | always `feedback` (distinguishes from other memory types). |
+| `originSessionId` | recommended, not required | Session ID where the friction was first observed (audit trail). If absent, the file is still valid but loses traceability. |
+| `**Why:**` body section | yes | Start of line, exact form `**Why:** ` (with trailing space). Without this, the file rots — readers can't judge if it still applies. |
+| `**How to apply:**` body section | yes | Start of line, exact form `**How to apply:** `. Vague rules don't change behavior. |
+
+### Filename slug (independent from `name`)
+
+The `<slug>` in the filename `feedback_<slug>.md` is **separately chosen** by retro-skill, kebab-case, descriptive of the learning topic. It is NOT required to match `frontmatter.name`.
+
+Canonical examples demonstrate the freedom: file `feedback_skill-sources.md` has `name: "skill source vs cache"`; file `feedback_no-version-bumps-in-feature-prs.md` has `name: "No version bumps in feature PRs"`.
 
 ## Project-rule placement
 
 When `retro-skill` materializes a `project-rule` destination:
 
-1. **Write file:** `<project>/docs/feedback/<slug>.md` (create `docs/feedback/` if missing)
-2. **Add AGENTS.md index entry:** under a `## Approved learnings` section:
+1. **Write file:** `<project>/docs/feedback/feedback_<slug>.md` (create `docs/feedback/` if missing).
+2. **Add AGENTS.md index entry** under a `## Approved learnings` section:
 
 ```markdown
 ## Approved learnings
 
-- [<slug>](docs/feedback/<slug>.md) — <one-line summary from frontmatter description>
+- [feedback_<slug>.md](docs/feedback/feedback_<slug>.md) — <one-line summary from frontmatter description>
 ```
 
-The index entry is a single line; the full prose lives in the linked file. This keeps AGENTS.md as an index (the agent-rules-skill conformance rule), not a rule dump.
+The index entry is a single line; the full prose lives in the linked file.
+
+### Section position in AGENTS.md
+
+`## Approved learnings` should be placed **after `## Key Decisions` and before `## Boundaries`** in the `root-thin.md` template's section order. **Place it outside `<!-- AGENTS-GENERATED:START ... -->` markers** so `generate-agents.sh --update` preserves it — this section is managed by retro-skill, not by the generator.
+
+If the project's AGENTS.md is at or near the 150-line cap (the harness AH-02 threshold), prune older inactive learnings or move to a scoped `AGENTS.md` rather than letting the index grow unbounded.
 
 ## User-memory placement
 
 When `retro-skill` materializes a `user-memory` destination:
 
-1. **Write file:** `~/.claude/projects/<slug>/memory/feedback_<slug>.md` (project-scoped) or `~/.claude/projects/<global>/memory/feedback_<slug>.md` if cross-project
-2. **Add MEMORY.md index entry:** under appropriate topic in the existing MEMORY.md index pattern
+1. **Compute path:** `~/.claude/projects/<project-dir-slug>/memory/feedback_<slug>.md` for project-scoped learnings, OR the global-scope path (consult `~/.claude/projects/`).
+2. **Write file** using the schema above.
+3. **Add MEMORY.md index entry** under the existing flat `## Topic Files` section (no sub-sections):
+
+```markdown
+- [feedback_<slug>.md](feedback_<slug>.md) — <one-line summary>
+```
+
+Do not create a separate `## Feedback` heading — MEMORY.md uses a single flat list.
 
 ## Why this schema (rationale)
 
-- **Frontmatter** is machine-readable and tool-discoverable
-- **`description`** lets retro-skill detect duplicates and rank relevance
-- **`Why:` + `How to apply:`** structure forces meaningful content; vague file = vague rule
-- **`originSessionId`** allows tracing back to the friction; supports audit and deprecation
+- **Frontmatter** is machine-readable and tool-discoverable.
+- **`description`** lets retro-skill detect duplicates and rank relevance.
+- **`Why:` + `How to apply:`** structure forces meaningful content; vague file = vague rule.
+- **`originSessionId`** allows tracing back to the friction; supports audit and deprecation.
 
 ## Validation
 
-A valid feedback file must have:
-- YAML frontmatter present and parseable
-- All required fields populated (non-empty)
-- Both `**Why:**` and `**How to apply:**` body sections present
-- File path matches `feedback_<name>.md` where `<name>` equals frontmatter `name`
+A valid feedback file has:
 
-Optional `scripts/verify-feedback-memory.sh` (TODO) can be added later to enforce this in CI.
+- YAML frontmatter present and parseable by PyYAML / yq.
+- Required fields populated (non-empty): `name`, `description`, `type`.
+- `description` is double-quoted (or doesn't contain YAML-special characters).
+- Both `**Why:** ` and `**How to apply:** ` body markers present at start-of-line.
+- File path matches `feedback_<slug>.md` where `<slug>` is kebab-case (independent of frontmatter `name`).
+
+`originSessionId` is recommended but its absence does NOT invalidate the file.
+
+Optional `scripts/verify-feedback-memory.sh` (not yet implemented; tracked as TODO) can enforce this in CI.
+
+## Validation gap (current state)
+
+`references/verification-guide.md` does **not** yet include a row for feedback files. Adding the check is tracked separately. retro-skill's PR-time validation of materialized files is the de-facto enforcement until the agent-rules-skill validator catches up.
 
 ## Examples in the wild
 
-The user's own memory at `~/.claude/projects/-home-sme-p/memory/` contains 8 files following this schema:
+The user's own memory at `~/.claude/projects/-home-sme-p/memory/` contains **9 files** following this schema:
 
-- `feedback_skill-sources.md`
-- `feedback_skill-iteration-cadence.md`
-- `feedback_merge-strategy.md`
 - `feedback_dup-repo-verification.md`
-- `feedback_obsolete-docs-prefer-delete.md`
-- `feedback_subagent-default.md`
-- `feedback_preserve-commit-signing.md`
-- `feedback_no-version-bumps-in-feature-prs.md`
+- `feedback_merge-strategy.md`
 - `feedback_merge-vs-rollout.md`
+- `feedback_no-version-bumps-in-feature-prs.md`
+- `feedback_obsolete-docs-prefer-delete.md`
+- `feedback_preserve-commit-signing.md`
+- `feedback_skill-iteration-cadence.md`
+- `feedback_skill-sources.md`
+- `feedback_subagent-default.md`
 
-These are canonical references for the format.
+Some include an extended `metadata:` block (e.g. `feedback_merge-vs-rollout.md` has `metadata: { node_type: memory, type: feedback }`); that variant is tolerated, not required.
 
 ## See also
 
-- `retro-skill/references/destination-taxonomy.md` — Where this schema applies
-- `retro-skill/references/patch-workflow.md` — How retro-skill writes these
+- `retro-skill/references/destination-taxonomy.md` — Where this schema applies (in retro-skill repo)
+- `retro-skill/references/patch-workflow.md` — How retro-skill writes these (in retro-skill repo)
 - `references/output-structure.md` — How AGENTS.md indexes feedback files
 - `references/verification-guide.md` — How to validate the resulting AGENTS.md

--- a/skills/agent-rules/references/feedback-memory-schema.md
+++ b/skills/agent-rules/references/feedback-memory-schema.md
@@ -1,0 +1,97 @@
+# Feedback Memory Schema
+
+Canonical format for **approved session learnings** materialized as project-rule or user-memory files. This schema is the contract between `retro-skill` (which writes these files) and `agent-rules-skill` (which manages how they integrate with AGENTS.md and project documentation).
+
+## When this schema applies
+
+- **user-memory destination:** `retro-skill` writes to `~/.claude/projects/<slug>/memory/feedback_<slug>.md`
+- **project-rule destination:** `retro-skill` writes to `<project>/docs/feedback/<slug>.md`
+
+Both files use the same schema. The location indicates the scope.
+
+## Schema
+
+```markdown
+---
+name: <kebab-case-slug>
+description: <one-line summary; used for relevance scoring across sessions>
+type: feedback
+originSessionId: <session-id-from-jsonl-filename, optional but recommended>
+---
+**Why:** <1-2 paragraphs explaining the friction and root cause>
+
+**How to apply:** <1-2 paragraphs describing how the assistant should behave next time>
+```
+
+### Field semantics
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | kebab-case slug, used in filename (`feedback_<name>.md`) |
+| `description` | yes | one-line summary, ≤200 chars; used by retro-skill to score relevance against new friction |
+| `type` | yes | always `feedback` (distinguishes from other memory types) |
+| `originSessionId` | recommended | Session ID where the friction was first observed (audit trail) |
+| `**Why:** …` | yes | Root cause analysis. Without this, the file rots — readers can't judge if it still applies. |
+| `**How to apply:** …` | yes | Concrete action for the agent. Vague rules don't change behavior. |
+
+## Project-rule placement
+
+When `retro-skill` materializes a `project-rule` destination:
+
+1. **Write file:** `<project>/docs/feedback/<slug>.md` (create `docs/feedback/` if missing)
+2. **Add AGENTS.md index entry:** under a `## Approved learnings` section:
+
+```markdown
+## Approved learnings
+
+- [<slug>](docs/feedback/<slug>.md) — <one-line summary from frontmatter description>
+```
+
+The index entry is a single line; the full prose lives in the linked file. This keeps AGENTS.md as an index (the agent-rules-skill conformance rule), not a rule dump.
+
+## User-memory placement
+
+When `retro-skill` materializes a `user-memory` destination:
+
+1. **Write file:** `~/.claude/projects/<slug>/memory/feedback_<slug>.md` (project-scoped) or `~/.claude/projects/<global>/memory/feedback_<slug>.md` if cross-project
+2. **Add MEMORY.md index entry:** under appropriate topic in the existing MEMORY.md index pattern
+
+## Why this schema (rationale)
+
+- **Frontmatter** is machine-readable and tool-discoverable
+- **`description`** lets retro-skill detect duplicates and rank relevance
+- **`Why:` + `How to apply:`** structure forces meaningful content; vague file = vague rule
+- **`originSessionId`** allows tracing back to the friction; supports audit and deprecation
+
+## Validation
+
+A valid feedback file must have:
+- YAML frontmatter present and parseable
+- All required fields populated (non-empty)
+- Both `**Why:**` and `**How to apply:**` body sections present
+- File path matches `feedback_<name>.md` where `<name>` equals frontmatter `name`
+
+Optional `scripts/verify-feedback-memory.sh` (TODO) can be added later to enforce this in CI.
+
+## Examples in the wild
+
+The user's own memory at `~/.claude/projects/-home-sme-p/memory/` contains 8 files following this schema:
+
+- `feedback_skill-sources.md`
+- `feedback_skill-iteration-cadence.md`
+- `feedback_merge-strategy.md`
+- `feedback_dup-repo-verification.md`
+- `feedback_obsolete-docs-prefer-delete.md`
+- `feedback_subagent-default.md`
+- `feedback_preserve-commit-signing.md`
+- `feedback_no-version-bumps-in-feature-prs.md`
+- `feedback_merge-vs-rollout.md`
+
+These are canonical references for the format.
+
+## See also
+
+- `retro-skill/references/destination-taxonomy.md` — Where this schema applies
+- `retro-skill/references/patch-workflow.md` — How retro-skill writes these
+- `references/output-structure.md` — How AGENTS.md indexes feedback files
+- `references/verification-guide.md` — How to validate the resulting AGENTS.md

--- a/skills/agent-rules/references/output-structure.md
+++ b/skills/agent-rules/references/output-structure.md
@@ -33,6 +33,11 @@ Additional recommended sections:
 - Good vs Bad examples
 - When stuck
 - House Rules (for scoped overrides)
+- **Approved learnings** — index entries linking to `docs/feedback/<slug>.md` (one line per learning, see [feedback-memory-schema.md](feedback-memory-schema.md))
+
+### AGENTS.md is an index, not a rule dump
+
+When session learnings are approved (via `/retro` or similar), the **prose lives in `docs/feedback/<slug>.md`** following the [feedback memory schema](feedback-memory-schema.md). AGENTS.md only carries a one-line link per learning under `## Approved learnings`. This keeps AGENTS.md compact (the agent-harness conformance rule) while preserving full audit trail in `docs/feedback/`.
 
 ## When to Customize vs Auto-Generate
 

--- a/skills/agent-rules/references/output-structure.md
+++ b/skills/agent-rules/references/output-structure.md
@@ -33,11 +33,15 @@ Additional recommended sections:
 - Good vs Bad examples
 - When stuck
 - House Rules (for scoped overrides)
-- **Approved learnings** — index entries linking to `docs/feedback/<slug>.md` (one line per learning, see [feedback-memory-schema.md](feedback-memory-schema.md))
+- **Approved learnings** — index entries linking to `docs/feedback/feedback_<slug>.md` (one line per learning, see [feedback-memory-schema.md](feedback-memory-schema.md))
 
 ### AGENTS.md is an index, not a rule dump
 
-When session learnings are approved (via `/retro` or similar), the **prose lives in `docs/feedback/<slug>.md`** following the [feedback memory schema](feedback-memory-schema.md). AGENTS.md only carries a one-line link per learning under `## Approved learnings`. This keeps AGENTS.md compact (the agent-harness conformance rule) while preserving full audit trail in `docs/feedback/`.
+When session learnings are approved (via `/retro` or similar), the **prose lives in `docs/feedback/feedback_<slug>.md`** following the [feedback memory schema](feedback-memory-schema.md). AGENTS.md only carries a one-line link per learning under `## Approved learnings`. This keeps AGENTS.md compact (the agent-harness conformance rule) while preserving full audit trail in `docs/feedback/`.
+
+Place `## Approved learnings` **after `## Key Decisions` and before `## Boundaries`** in the section order, and put it **outside** any `<!-- AGENTS-GENERATED:START ... -->` markers — this section is managed by retro-skill, not by `generate-agents.sh`, so it must survive `--update` runs.
+
+If the approved-learnings index would push AGENTS.md over the harness 150-line cap (`AH-02`), prune inactive entries or move to a scoped `AGENTS.md` rather than letting the index grow unbounded.
 
 ## When to Customize vs Auto-Generate
 


### PR DESCRIPTION
## Summary

Adds `references/feedback-memory-schema.md` documenting the canonical format for approved session learnings as materialized by [retro-skill](https://github.com/netresearch/retro-skill) into user-memory or project-rule destinations.

Updates `references/output-structure.md` to clarify that AGENTS.md is an index and approved learnings live in `docs/feedback/<slug>.md` with one-line entries under '## Approved learnings'.

## Came from

Spec: [agent-harness-skill `feat/spec-retro-skill` branch](https://github.com/netresearch/agent-harness-skill/tree/feat/spec-retro-skill) → docs/specs/retro-skill.md
Companion to https://github.com/netresearch/retro-skill v0.1.0

## Change

- new: `skills/agent-rules/references/feedback-memory-schema.md`
- edit: `skills/agent-rules/references/output-structure.md`

## Test plan

- [x] References the canonical 8 existing `feedback_*.md` files in `~/.claude/projects/-home-sme-p/memory/`
- [ ] retro-skill consuming this schema produces valid feedback files