### PR TITLE
chore(release): v3.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-rules",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "repository": "https://github.com/netresearch/agent-rules-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, jq 1.5+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.9.1"
+  version: "3.10.0"
   repository: https://github.com/netresearch/agent-rules-skill
 allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
 ---


### PR DESCRIPTION
## Release v3.10.0

Minor release. Bumps `.claude-plugin/plugin.json` and `skills/agent-rules/SKILL.md` frontmatter `metadata.version` from `3.9.1` to `3.10.0`.

### Highlights since v3.9.1

- **npm distribution** — the skill now ships as an npm package via `@netresearch/agent-skill-coordinator`, enabling install paths beyond Composer and the Claude Code marketplace (#46).
- **retro-skill integration** — new `feedback-memory-schema.md` reference describes the structured format the `retro` skill produces, so generated AGENTS.md content can co-evolve with retro-driven feedback memories (#48).

### Maintenance

- Dropped deprecated `with: bump:` block and `workflow_dispatch.bump` input from the release caller (#45) — aligns with `skill-repo-skill`'s signed-tag-only release model.
- Granted `id-token: write` / `attestations: write` so the reusable release workflow can emit SLSA build provenance (#44).
- See Also section now links companion skills as clickable Markdown links (#43).
- Doc fixes: 3 Cs framework labels, citations for contribution-guidelines / directory-coverage refs (#47).

### Release plan

After merge:
1. `git checkout main && git pull --rebase`
2. `git tag -s v3.10.0 -m "v3.10.0"` then `git push origin v3.10.0`
3. Reusable release workflow at `netresearch/skill-repo-skill/.github/workflows/release.yml` publishes archives + SHA256SUMS with cosign + SLSA attestation.
4. Overhaul auto-generated release notes via `gh release edit v3.10.0 --notes-file …`.

Pilots the standardized release flow before the same pattern is applied across the other Netresearch skill repos.