### PR TITLE
fix(ci): drop workflow-level permissions cap from Security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,21 +1,24 @@
 name: Security
 
+# Permissions note: when calling reusable workflows we let the called
+# workflow's own per-job permissions apply (the reusables declare
+# `permissions: {}` at the top level and elevate per job as needed —
+# e.g. gitleaks/composer-audit need `security-events: write` for SARIF
+# upload). A workflow-level `permissions: contents: read` block here
+# would cap every job below it, causing reusables that need to elevate
+# (composer-audit, gitleaks SARIF) to fail at workflow startup. Only
+# dependency-review (which uses an *action*, not a reusable workflow)
+# needs caller-side permissions.
+
 on:
   push:
     branches: [main, master]
   pull_request:
     branches: [main, master]
 
-# Principle of least privilege: top-level grants the minimum every job
-# needs. Jobs that need more expand their own permissions block below.
-permissions:
-  contents: read
-
 jobs:
   gitleaks:
     uses: netresearch/.github/.github/workflows/gitleaks.yml@main
-    permissions:
-      contents: read
     secrets:
       GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
@@ -28,6 +31,3 @@ jobs:
 
   composer-audit:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
-    permissions:
-      contents: read
-      security-events: write  # SARIF upload for SAST scan

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,14 +1,19 @@
 name: Security
 
-# Permissions note: when calling reusable workflows we let the called
-# workflow's own per-job permissions apply (the reusables declare
-# `permissions: {}` at the top level and elevate per job as needed —
-# e.g. gitleaks/composer-audit need `security-events: write` for SARIF
-# upload). A workflow-level `permissions: contents: read` block here
-# would cap every job below it, causing reusables that need to elevate
-# (composer-audit, gitleaks SARIF) to fail at workflow startup. Only
-# dependency-review (which uses an *action*, not a reusable workflow)
-# needs caller-side permissions.
+# Permissions note: do NOT add a workflow-level `permissions:` block here.
+# The reusables called below (gitleaks, dependency-review, composer-audit)
+# declare `permissions: {}` at top-level and grant what each job needs at
+# the job level. A workflow-level cap of e.g. `contents: read` here would
+# conflict with any caller-side job-level block that elevates beyond the
+# cap, causing the workflow to startup_failure at dispatch time (this is
+# exactly what was broken on this repo 2026-05-06 → 2026-05-23 and what
+# this PR fixes).
+#
+# Per-job `permissions:` blocks on `uses:` reusable-workflow calls are
+# left to the workflows themselves where possible. dependency-review keeps
+# a caller-side block because that's the pattern used by the working peer
+# skill repos (skill-repo-skill etc.) — defensive symmetry with what
+# dependency-review.yml's job grants internally.
 
 on:
   push:


### PR DESCRIPTION
## Summary

The Security workflow has been `startup_failure`-ing on every push and PR for **17 consecutive days** (since 2026-05-06). This PR fixes it by aligning with the pattern used by working peer skill repos.

| Run | Result |
|---|---|
| 2026-05-23 push → main | [`startup_failure`](https://github.com/netresearch/agent-rules-skill/actions/runs/26325600061) |
| 2026-05-15 push → main | startup_failure |
| 2026-05-12 push → main | startup_failure |
| 2026-05-06 push → main | startup_failure |
| 2026-04-18 push → main | (last success — before workflow-level permissions block was added) |

## Root cause (timeline-confirmed)

1. **2026-04-18** ([`c6f1d2c`](https://github.com/netresearch/agent-rules-skill/commit/c6f1d2c)): added explicit workflow-level `permissions: contents: read` + per-job permissions blocks "for CodeQL's actions analyzer". Worked initially because the called reusable workflows allowed elevation.
2. **2026-05-05** ([`netresearch/.github` `7faee5f`](https://github.com/netresearch/.github/commit/7faee5f)): the shared gitleaks reusable was rewritten to use betterleaks. The new reusable declares `permissions: {}` at top-level.
3. **2026-05-06+**: every Security run startup-fails because the caller declares a workflow-level cap of `contents: read`, but the `composer-audit` job below it asks for `security-events: write` — which **exceeds** the workflow-level cap. GitHub refuses to start the workflow.

## Fix

Remove the workflow-level `permissions: contents: read` cap and the redundant per-job permissions on `gitleaks` and `composer-audit` (which the called reusables already grant at their own job level). Keep `dependency-review`'s caller-side permissions — that one uses a GitHub *action*, not a reusable workflow, so caller-side elevation is required.

Adds an inline comment block explaining the reasoning so future contributors don't re-introduce the cap and re-break the workflow.

## Peer comparison

The working peers ([`skill-repo-skill`](https://github.com/netresearch/skill-repo-skill/blob/main/.github/workflows/security.yml), [`go-development-skill`](https://github.com/netresearch/go-development-skill/blob/main/.github/workflows/security.yml), [`php-modernization-skill`](https://github.com/netresearch/php-modernization-skill/blob/main/.github/workflows/security.yml), [`agent-harness-skill`](https://github.com/netresearch/agent-harness-skill/blob/main/.github/workflows/security.yml)) all use this exact pattern and have been green on Security for months. This PR aligns this repo with that pattern.

## Verification

- `actionlint` against the new file → clean
- `yamllint` (CI defaults) against the new file → clean
- CI on this PR will be the first definitive test — if Security goes green on the PR, the fix is verified

This is the agent-rules-skill / agents-skill repo (rename-alias); the same fix benefits both names.