### PR TITLE
chore(release): v3.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-rules",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "repository": "https://github.com/netresearch/agent-rules-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, jq 1.5+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.10.0"
+  version: "3.11.0"
   repository: https://github.com/netresearch/agent-rules-skill
 allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
 ---


### PR DESCRIPTION
Release **v3.11.0** (minor bump, conventional commits since v3.10.0).

Bumps `.claude-plugin/plugin.json` + `SKILL.md` version to 3.11.0.

Changes since v3.10.0:
- feat: add .pre-commit-config.yaml mirroring CI checks
- 
- Wires netresearch/skill-repo-skill@v1.22.0 as a pre-commit hook
- provider so validate-skill, check-version-parity, and the standard
- linter set (markdownlint-cli2, yamllint, actionlint, ruff, shellcheck)
- run locally before commit instead of only in CI.
- - package.json scripts.prepare: invokes pre-commit install --install-hooks
-   if pre-commit is on PATH; silent no-op otherwise. Auto-activates hooks
-   on `npm install`.
- 
- Part of the fleet rollout following netresearch/agent-harness-skill#27
- (CI/Hook Parity Principle) and skill-repo-skill v1.22.0 (hook exposure).
- 
- Signed-off-by: Sebastian Mendel <info@sebastianmendel.de>
- feat: add .pre-commit-config.yaml mirroring CI checks (#50)
- 
- ## Summary
- 
- Wires
- [`netresearch/skill-repo-skill@v1.22.0`](https://github.com/netresearch/skill-repo-skill/releases/tag/v1.22.0)

After merge: a signed tag `v3.11.0` on `main` triggers the release workflow.