### PR TITLE
feat(agent-rules): AGENTS.md quality grading + verifier --json + content anti-patterns

### DIFF
--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -30,6 +30,7 @@ Generate and maintain AGENTS.md files following the [agents.md convention](https
 | `scripts/check-freshness.sh PATH` | Check if files are outdated |
 | `scripts/verify-content.sh PATH` | Verify documented files/commands match codebase |
 | `scripts/verify-commands.sh PATH` | Verify documented commands execute |
+| `scripts/score-agents.sh PATH` | Grade AGENTS.md quality 0-100, worst-first (reproducible) |
 | `scripts/detect-project.sh PATH` | Detect language, version, build tools |
 | `scripts/detect-scopes.sh PATH` | Identify directories needing scoped files |
 | `scripts/extract-commands.sh PATH` | Extract commands from build configs |
@@ -60,8 +61,9 @@ Use `--update` to preserve human-curated content outside `<!-- GENERATED -->` ma
 
 | File | Contents |
 |------|----------|
-| [`verification-guide.md`](references/verification-guide.md) | Verification steps, design principles |
+| [`verification-guide.md`](references/verification-guide.md) | Verification steps, design principles, what NOT to add |
 | [`scripts-guide.md`](references/scripts-guide.md) | Script options, validation checklist |
+| [`quality-rubric.md`](references/quality-rubric.md) | Quality grading: deterministic axes + LLM overlay |
 | [`ai-tool-compatibility.md`](references/ai-tool-compatibility.md) | 16-agent compatibility matrix |
 | [`output-structure.md`](references/output-structure.md) | Root/scoped sections |
 | [`git-hooks-setup.md`](references/git-hooks-setup.md) | Hook framework detection and setup |

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -30,7 +30,7 @@ Generate and maintain AGENTS.md files following the [agents.md convention](https
 | `scripts/check-freshness.sh PATH` | Check if files are outdated |
 | `scripts/verify-content.sh PATH` | Verify documented files/commands match codebase |
 | `scripts/verify-commands.sh PATH` | Verify documented commands execute |
-| `scripts/score-agents.sh PATH` | Grade AGENTS.md quality 0-100, worst-first (reproducible) |
+| `scripts/score-agents.sh PATH` | Grade AGENTS.md quality, worst-first |
 | `scripts/detect-project.sh PATH` | Detect language, version, build tools |
 | `scripts/detect-scopes.sh PATH` | Identify directories needing scoped files |
 | `scripts/extract-commands.sh PATH` | Extract commands from build configs |
@@ -61,19 +61,19 @@ Use `--update` to preserve human-curated content outside `<!-- GENERATED -->` ma
 
 | File | Contents |
 |------|----------|
-| [`verification-guide.md`](references/verification-guide.md) | Verification steps, design principles, what NOT to add |
+| [`verification-guide.md`](references/verification-guide.md) | Verification steps, design principles, anti-bloat |
 | [`scripts-guide.md`](references/scripts-guide.md) | Script options, validation checklist |
-| [`quality-rubric.md`](references/quality-rubric.md) | Quality grading: deterministic axes + LLM overlay |
+| [`quality-rubric.md`](references/quality-rubric.md) | Quality grading rubric |
 | [`ai-tool-compatibility.md`](references/ai-tool-compatibility.md) | 16-agent compatibility matrix |
 | [`output-structure.md`](references/output-structure.md) | Root/scoped sections |
 | [`git-hooks-setup.md`](references/git-hooks-setup.md) | Hook framework detection and setup |
 | [`examples/`](references/examples/) | Complete examples |
-| [`ai-contribution-guidelines.md`](references/ai-contribution-guidelines.md) | "3 Cs" framework for AI contributions (Comprehension, Context, Continuity) |
-| [`directory-coverage.md`](references/directory-coverage.md) | Full coverage rationale for scoped AGENTS.md files |
+| [`ai-contribution-guidelines.md`](references/ai-contribution-guidelines.md) | "3 Cs" framework for AI contributions |
+| [`directory-coverage.md`](references/directory-coverage.md) | Scoped-file coverage rationale |
 
 ## Templates
 
-Root: `assets/root-thin.md` (default), `root-verbose.md`. Scoped: `assets/scoped/` -- `backend-go.md`, `backend-php.md`, `python-modern.md`, `typo3.md`, `symfony.md`, `skill-repo.md`, `cli.md`, `frontend-typescript.md`, `oro.md`.
+Root: `assets/root-thin.md` (default) or `root-verbose.md`. Scoped: `assets/scoped/`, one per stack (Go/PHP/Python/TYPO3/Symfony/Oro/CLI/TS/skill-repo).
 
 ## Supported Projects
 
@@ -81,5 +81,5 @@ Go, PHP (Composer/Laravel/Symfony/TYPO3/Oro), TypeScript (React/Next/Vue/Node), 
 
 ## See Also
 
-- [`agent-harness-skill`](https://github.com/netresearch/agent-harness-skill) — broader agent-readiness harness (CI verification, enforcement). Invokes this skill when AGENTS.md is missing.
+- [`agent-harness-skill`](https://github.com/netresearch/agent-harness-skill) — broader agent-readiness harness (CI verification, enforcement).
 - [`skill-repo-skill`](https://github.com/netresearch/skill-repo-skill) — skill-repo structure (plugin.json, split licensing, release workflows).

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -2,7 +2,7 @@
 name: agent-rules
 description: "Use when creating or updating AGENTS.md files, .github/copilot-instructions.md, or other AI agent rule files, onboarding AI agents to a project, standardizing agent documentation, or when anyone mentions AGENTS.md, agent rules, project onboarding, or codebase documentation for AI agents."
 license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
-compatibility: "Requires bash 4.3+, jq 1.5+, git 2.0+."
+compatibility: "Requires bash 4.3+, jq 1.7+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
   version: "3.11.0"

--- a/skills/agent-rules/references/quality-rubric.md
+++ b/skills/agent-rules/references/quality-rubric.md
@@ -1,0 +1,79 @@
+# AGENTS.md Quality Rubric
+
+Grade AGENTS.md files so you know which ones most need work. The grade has two
+layers that are **kept separate on purpose**:
+
+1. **Deterministic score** — `scripts/score-agents.sh PATH`. A 0-100 from the four
+   verifier scripts; no model call, so re-running on an unchanged tree gives the
+   same grade — except a file dated *today*, where git's bare-date `--since` can
+   shift the Currency axis within the day.
+2. **Qualitative LLM overlay** — three axes a *reading agent* judges (below).
+   These vary between runs, so they are **never folded into the deterministic
+   number**; present them as a separate annotation.
+
+## Deterministic axes (score-agents.sh)
+
+| Axis | Max | Source | What it measures |
+|------|-----|--------|------------------|
+| Structure | 25 | `validate-structure.sh --json` | Managed header, thin root, precedence, scope links, CLAUDE.md symlink, required scoped sections |
+| Currency | 20 | `check-freshness.sh --json` | Commits in scope since the file's "Last updated" date |
+| Content | 20 | `verify-content.sh --json` | Documented files/commands/counts that match reality |
+| Commands | 15 | `verify-commands.sh --json` | Documented commands that actually run (root only) |
+| Conciseness | 20 | line count vs budget | Root ≤50 lines ideal; scoped files get a larger budget |
+
+Per file: `percent = earned / (sum of applicable axis maxima) × 100`. Scoped
+files have no Commands axis (maxima sum to 85, normalised to 100).
+
+Grades: **A ≥90 · B ≥75 · C ≥50 · D ≥30 · F <30**.
+
+## Qualitative LLM overlay (agent-judged)
+
+Run after the deterministic score. Read each AGENTS.md and rate three axes the
+scripts cannot measure. Use **strong / adequate / weak** with a one-line reason.
+
+| Axis | Strong | Weak |
+|------|--------|------|
+| **Architecture clarity** | A new agent can place code from the file alone — key dirs, module relationships, entry points | Vague or missing structure; "see the code" |
+| **Actionability** | Concrete, copy-paste commands, real paths, decisive heuristics ("squash-merge", "ask first") | Theoretical advice ("follow best practices", "write good tests") |
+| **Non-obvious patterns** | Captures what code can't tell you — ordering deps, quirks, "why we do it this way" | Only restates what the filenames already say |
+
+### How to feed it back: `--review`
+
+Rate each file, write the ratings to JSON, and pass it to the scorer. It keeps the
+deterministic grade as the headline and adds a clearly-labelled, **non-reproducible**
+secondary grade:
+
+```bash
+cat > /tmp/review.json <<'JSON'
+{
+  "AGENTS.md":     {"architecture":"strong","actionability":"adequate","non_obvious":"weak"},
+  "web/AGENTS.md": {"architecture":"weak","actionability":"weak","non_obvious":"weak"}
+}
+JSON
+scripts/score-agents.sh PATH --review /tmp/review.json
+```
+
+```
+  B  78/100    AGENTS.md
+       structure 25/25  currency 15/20  content 18/20  conciseness 20/20  commands 0/15
+       with review: B ~75/100  (non-reproducible)
+```
+
+Rating → fraction of the axis max: **strong = 1.0 · adequate = 0.6 · weak = 0.2**.
+Blended = `(deterministic_earned + llm_earned) / (deterministic_max + 25) × 100`.
+The headline `percent`/`grade` are **byte-identical** with or without `--review` —
+the overlay never moves the reproducible number.
+
+- The overlay's job is to catch files that **score well but read poorly** — e.g.
+  structurally complete (B+) yet every line is obvious, or actionability is vague.
+  Those are the highest-value edits.
+- The blended figure varies between reviews (model judgement); the deterministic
+  headline stays put. Always cite both, never the blended number alone.
+
+## Workflow
+
+1. `scripts/score-agents.sh PATH` → deterministic report (worst-first).
+2. Open the worst-graded files; run the three overlay axes on each.
+3. Fix highest-leverage gaps first (a `D` on Structure is mechanical; a `weak`
+   on Non-obvious patterns needs human/session knowledge — see
+   [`feedback-memory-schema.md`](feedback-memory-schema.md) and the retro-skill).

--- a/skills/agent-rules/references/scripts-guide.md
+++ b/skills/agent-rules/references/scripts-guide.md
@@ -146,6 +146,29 @@ Options:
 
 **Why this matters:** Research shows broken commands waste 500+ tokens as agents debug non-existent commands. Verified commands enable confident execution.
 
+## Scoring Quality
+
+```bash
+scripts/score-agents.sh /path/to/project          # human report, worst-first
+scripts/score-agents.sh /path/to/project --json   # machine-readable scoring
+```
+
+Aggregates the `--json` output of the four verifier scripts into a **reproducible**
+0-100 grade per AGENTS.md file (A-F), ranked worst-first so you know where to spend
+effort. Same tree → same grade (no model call; CI-friendly).
+
+Axes: Structure 25 · Currency 20 · Content 20 · Commands 15 (root) · Conciseness 20.
+Scoped files have no Commands axis and normalise over the remaining 85.
+
+The four verifiers each gained a `--json` mode (strictly additive — default output
+is unchanged). For the qualitative LLM overlay (Architecture / Actionability /
+Non-obvious patterns), which is deliberately **not** part of the deterministic
+number, see [`quality-rubric.md`](quality-rubric.md).
+
+> Note: `score-agents.sh` grades whatever `validate-structure.sh` lists, which does
+> not honour `.gitignore` (it will include generated/vendored AGENTS.md under the
+> tree). Point it at a clean project root, or exclude such trees, for a clean grade.
+
 ## Post-Generation Validation Checklist
 
 **After generating AGENTS.md files, ALWAYS validate the output:**

--- a/skills/agent-rules/references/verification-guide.md
+++ b/skills/agent-rules/references/verification-guide.md
@@ -95,6 +95,47 @@ ls tests/*.py tests/**/*.py
 - **WRONG:** Using extracted command output without running it
 - **RIGHT:** Extract -> Compare -> Fix discrepancies -> Validate
 
+## What NOT to Put in a Root AGENTS.md
+
+The **root** AGENTS.md is auto-loaded into every session -- each line spends prompt
+budget that is never reclaimed. Be ruthless here. (Scoped/subdirectory files load on
+demand, so they can carry more detail; this economy applies hardest to the root.)
+
+| Don't add | Why | Instead |
+|-----------|-----|---------|
+| Restating what the filename/code already says | The agent reads the code anyway | Document only what is *not* derivable |
+| Generic best practices ("write tests", "use clear names") | Universal advice, not project-specific | Cut it -- the model already knows |
+| One-off fixes ("fixed login bug in #123") | Won't recur; pure clutter | Cut it; it lives in git history |
+| Tutorials on well-known tech (what JWT/Docker *is*) | Wastes tokens on what the model knows | One line: the project's *choice*, not the lesson |
+| Duplicating a scoped file's content in root | Breaks the Pointer Principle | Link to the scoped `AGENTS.md` |
+
+### Compression: bad -> good
+
+Each rewrite keeps the project-specific signal and drops the filler.
+
+**Obvious-code restatement**
+
+- BAD: `The UserService class handles user-related operations.`
+- GOOD: *(omit -- the class name already says this)*
+
+**Tutorial instead of the project's choice**
+
+- BAD: `Auth uses JWT. JSON Web Tokens (RFC 7519) are a compact, self-contained way to transmit signed claims as JSON; we picked HS256 because...`
+- GOOD: `Auth: JWT (HS256), Bearer token in the Authorization header.`
+
+**Generic advice**
+
+- BAD: `Always validate user input and write tests for new features.`
+- GOOD: *(omit -- universal, not specific to this repo)*
+
+**Prose where a pointer wins**
+
+- BAD: `To run the tests, first install dependencies with composer, then run the PHPUnit suite through the composer test script...`
+- GOOD: `Tests: composer test (PHPUnit). See Tests/AGENTS.md.`
+
+> **Litmus test:** *"Would a senior engineer who knows this stack but not this repo
+> learn something from this line?"* If no, cut it.
+
 ## Agent-Optimized Design
 
 This skill generates AGENTS.md files optimized for AI coding agent efficiency based on:

--- a/skills/agent-rules/scripts/check-freshness.sh
+++ b/skills/agent-rules/scripts/check-freshness.sh
@@ -208,9 +208,13 @@ if [ -z "$AGENTS_FILES" ]; then
     exit 0
 fi
 
-# Check each file
+# Check each file.
+# `|| true`: check_file_freshness returns non-zero for stale/unknown files; without
+# this guard `set -e` aborts the loop on the first such file, processing only one
+# file and defeating the summary below (and forcing the validate-structure caller to
+# always warn). Tolerating the non-zero lets every file be counted.
 while read -r file; do
-    check_file_freshness "$file"
+    check_file_freshness "$file" || true
     echo ""
 done <<< "$AGENTS_FILES"
 

--- a/skills/agent-rules/scripts/check-freshness.sh
+++ b/skills/agent-rules/scripts/check-freshness.sh
@@ -63,7 +63,7 @@ fi
 # original stdout (fd 3) for the single JSON document emitted at the end. This
 # keeps --json strictly additive: the default (no-flag) path is untouched.
 JSON_FILES=()
-if [ "$JSON" = true ]; then
+if [[ "$JSON" = true ]]; then
     exec 3>&1 1>/dev/null
 fi
 
@@ -173,7 +173,7 @@ check_file_freshness() {
     if ! last_updated=$(extract_last_updated "$agents_file"); then
         echo "  ⚠️  No 'Last updated' date found in header"
         ((UNKNOWN_COUNT++)) || true
-        if [ "$JSON" = true ]; then
+        if [[ "$JSON" = true ]]; then
             JSON_FILES+=("$(jq -nc --arg path "$rel_path" \
                 '{path:$path,status:"unknown",last_updated:null,commits_since:null}')")
         fi
@@ -192,7 +192,7 @@ check_file_freshness() {
     if [ "$commit_count" -eq 0 ]; then
         echo "  ✅ Up to date (no commits since $last_updated)"
         ((FRESH_COUNT++)) || true
-        if [ "$JSON" = true ]; then
+        if [[ "$JSON" = true ]]; then
             JSON_FILES+=("$(jq -nc --arg path "$rel_path" --arg lu "$last_updated" \
                 '{path:$path,status:"fresh",last_updated:$lu,commits_since:0}')")
         fi
@@ -202,7 +202,7 @@ check_file_freshness() {
     # Check if commits are significant
     echo "  ⚠️  Potentially stale: $commit_count commit(s) since $last_updated"
     ((STALE_COUNT++)) || true
-    if [ "$JSON" = true ]; then
+    if [[ "$JSON" = true ]]; then
         JSON_FILES+=("$(jq -nc --arg path "$rel_path" --arg lu "$last_updated" --argjson cs "$commit_count" \
             '{path:$path,status:"stale",last_updated:$lu,commits_since:$cs}')")
     fi
@@ -245,8 +245,8 @@ while read -r file; do
 done <<< "$AGENTS_FILES"
 
 # Emit JSON document (machine-readable) and exit before the human summary.
-if [ "$JSON" = true ]; then
-    if [ "${#JSON_FILES[@]}" -eq 0 ]; then
+if [[ "$JSON" = true ]]; then
+    if [[ "${#JSON_FILES[@]}" -eq 0 ]]; then
         files_json='[]'
     else
         files_json=$(printf '%s\n' "${JSON_FILES[@]}" | jq -s '.')
@@ -257,7 +257,7 @@ if [ "$JSON" = true ]; then
         --argjson stale "$STALE_COUNT" \
         --argjson unknown "$UNKNOWN_COUNT" \
         '{script:"check-freshness",schema:1,summary:{fresh:$fresh,stale:$stale,unknown:$unknown},files:$files}' >&3
-    if [ "$STALE_COUNT" -gt 0 ]; then exit 1; fi
+    if [[ "$STALE_COUNT" -gt 0 ]]; then exit 1; fi
     exit 0
 fi
 

--- a/skills/agent-rules/scripts/check-freshness.sh
+++ b/skills/agent-rules/scripts/check-freshness.sh
@@ -8,6 +8,7 @@ cd "$PROJECT_DIR"
 
 # Options
 VERBOSE=false
+JSON=false
 DAYS_THRESHOLD=7  # Warn if commits are older than this many days after last update (used below)
 
 # Parse flags
@@ -15,6 +16,10 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --verbose|-v)
             VERBOSE=true
+            shift
+            ;;
+        --json)
+            JSON=true
             shift
             ;;
         --threshold=*)
@@ -30,6 +35,7 @@ Check if AGENTS.md files are up to date with recent git commits.
 
 Options:
   --verbose, -v         Show detailed output including commit lists
+  --json                Emit machine-readable JSON on stdout (human output suppressed)
   --threshold=DAYS      Days after last update to consider stale (default: 7)
   --help, -h            Show this help message
 
@@ -51,6 +57,14 @@ done
 if ! git rev-parse --git-dir > /dev/null 2>&1; then
     echo "Error: Not a git repository"
     exit 1
+fi
+
+# In JSON mode, route all human-readable output to /dev/null and reserve the
+# original stdout (fd 3) for the single JSON document emitted at the end. This
+# keeps --json strictly additive: the default (no-flag) path is untouched.
+JSON_FILES=()
+if [ "$JSON" = true ]; then
+    exec 3>&1 1>/dev/null
 fi
 
 STALE_COUNT=0
@@ -159,6 +173,10 @@ check_file_freshness() {
     if ! last_updated=$(extract_last_updated "$agents_file"); then
         echo "  ⚠️  No 'Last updated' date found in header"
         ((UNKNOWN_COUNT++)) || true
+        if [ "$JSON" = true ]; then
+            JSON_FILES+=("$(jq -nc --arg path "$rel_path" \
+                '{path:$path,status:"unknown",last_updated:null,commits_since:null}')")
+        fi
         return 1
     fi
 
@@ -174,12 +192,20 @@ check_file_freshness() {
     if [ "$commit_count" -eq 0 ]; then
         echo "  ✅ Up to date (no commits since $last_updated)"
         ((FRESH_COUNT++)) || true
+        if [ "$JSON" = true ]; then
+            JSON_FILES+=("$(jq -nc --arg path "$rel_path" --arg lu "$last_updated" \
+                '{path:$path,status:"fresh",last_updated:$lu,commits_since:0}')")
+        fi
         return 0
     fi
 
     # Check if commits are significant
     echo "  ⚠️  Potentially stale: $commit_count commit(s) since $last_updated"
     ((STALE_COUNT++)) || true
+    if [ "$JSON" = true ]; then
+        JSON_FILES+=("$(jq -nc --arg path "$rel_path" --arg lu "$last_updated" --argjson cs "$commit_count" \
+            '{path:$path,status:"stale",last_updated:$lu,commits_since:$cs}')")
+    fi
 
     if [ "$VERBOSE" = true ]; then
         echo "  Recent commits:"
@@ -217,6 +243,23 @@ while read -r file; do
     check_file_freshness "$file" || true
     echo ""
 done <<< "$AGENTS_FILES"
+
+# Emit JSON document (machine-readable) and exit before the human summary.
+if [ "$JSON" = true ]; then
+    if [ "${#JSON_FILES[@]}" -eq 0 ]; then
+        files_json='[]'
+    else
+        files_json=$(printf '%s\n' "${JSON_FILES[@]}" | jq -s '.')
+    fi
+    jq -nc \
+        --argjson files "$files_json" \
+        --argjson fresh "$FRESH_COUNT" \
+        --argjson stale "$STALE_COUNT" \
+        --argjson unknown "$UNKNOWN_COUNT" \
+        '{script:"check-freshness",schema:1,summary:{fresh:$fresh,stale:$stale,unknown:$unknown},files:$files}' >&3
+    if [ "$STALE_COUNT" -gt 0 ]; then exit 1; fi
+    exit 0
+fi
 
 # Summary
 echo "=== Freshness Summary ==="

--- a/skills/agent-rules/scripts/score-agents.sh
+++ b/skills/agent-rules/scripts/score-agents.sh
@@ -78,8 +78,8 @@ fi
 
 # Optional LLM-axis ratings for the secondary "with review" grade.
 REVIEW_JSON='{}'
-if [ -n "$REVIEW_FILE" ]; then
-    if [ -f "$REVIEW_FILE" ] && jq -e . "$REVIEW_FILE" >/dev/null 2>&1; then
+if [[ -n "$REVIEW_FILE" ]]; then
+    if [[ -f "$REVIEW_FILE" ]] && jq -e . "$REVIEW_FILE" >/dev/null 2>&1; then
         REVIEW_JSON=$(cat "$REVIEW_FILE")
     else
         echo "Error: --review file missing or not valid JSON: $REVIEW_FILE" >&2
@@ -94,11 +94,12 @@ run_json() {
     shift
     local out
     out=$(bash "$SCRIPT_DIR/$script" "$PROJECT_DIR" --json "$@" 2>/dev/null || true)
-    if [ -n "$out" ] && printf '%s' "$out" | jq -e . >/dev/null 2>&1; then
+    if [[ -n "$out" ]] && printf '%s' "$out" | jq -e . >/dev/null 2>&1; then
         printf '%s' "$out"
     else
         echo '{}'
     fi
+    return 0
 }
 
 STRUCT_JSON=$(run_json validate-structure.sh)
@@ -114,10 +115,10 @@ lines_pairs=()
 for path in "${SPINE[@]}"; do
     full="$PROJECT_DIR/$path"
     n=0
-    [ -f "$full" ] && n=$(wc -l < "$full" | tr -d ' ')
+    [[ -f "$full" ]] && n=$(wc -l < "$full" | tr -d ' ')
     lines_pairs+=("$(jq -nc --arg p "$path" --argjson n "$n" '{key:$p,value:$n}')")
 done
-if [ "${#lines_pairs[@]}" -eq 0 ]; then
+if [[ "${#lines_pairs[@]}" -eq 0 ]]; then
     LINES_JSON='{}'
 else
     LINES_JSON=$(printf '%s\n' "${lines_pairs[@]}" | jq -s 'from_entries')
@@ -215,7 +216,7 @@ SCORING=$(jq -nc \
     }
     ')
 
-if [ "$JSON" = true ]; then
+if [[ "$JSON" = true ]]; then
     printf '%s\n' "$SCORING" | jq .
     exit 0
 fi

--- a/skills/agent-rules/scripts/score-agents.sh
+++ b/skills/agent-rules/scripts/score-agents.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# score-agents.sh - Grade AGENTS.md files with a reproducible quality score.
+#
+# Aggregates the --json output of the four verifier scripts into a per-file
+# letter grade (A-F) on a 0-100 scale, ranked worst-first so you know where to
+# spend effort. Reproducible: re-running on an unchanged tree yields the same
+# grade (no model call, CI-friendly). One caveat - the Currency axis can shift
+# within a day for a file whose "Last updated" date is today, because
+# check-freshness.sh uses git's bare-date --since.
+#
+# Five script-measured axes (max points):
+#   Structure 25 | Currency 20 | Content 20 | Commands 15 (root only) | Conciseness 20
+# A file's percentage = earned / (sum of applicable axis maxima) * 100.
+# Scoped files have no Commands axis; their maxima sum to 85 and normalise to 100.
+#
+# Grades: A >=90  B >=75  C >=50  D >=30  F <30
+#
+# A separate, QUALITATIVE LLM overlay (Architecture / Actionability /
+# Non-obvious-patterns) is NOT part of this number - it varies run to run. See
+# references/quality-rubric.md for how an agent layers that review on top.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROJECT_DIR=""
+JSON=false
+REVIEW_FILE=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --json)
+            JSON=true
+            shift
+            ;;
+        --review)
+            REVIEW_FILE="${2:-}"
+            shift 2
+            ;;
+        --review=*)
+            REVIEW_FILE="${1#*=}"
+            shift
+            ;;
+        --help|-h)
+            cat <<EOF
+Usage: score-agents.sh [PROJECT_DIR] [OPTIONS]
+
+Grade AGENTS.md files with a reproducible 0-100 quality score (worst-first).
+
+Options:
+  --json            Emit the machine-readable scoring document on stdout
+  --review FILE     Add a secondary, NON-reproducible "with review" grade from a
+                    JSON of agent-judged LLM-axis ratings (see quality-rubric.md):
+                    { "PATH": {"architecture":"strong|adequate|weak",
+                               "actionability":"...","non_obvious":"..."}, ... }
+  --help, -h        Show this help message
+
+Axes: Structure 25 | Currency 20 | Content 20 | Commands 15 (root) | Conciseness 20
+Grades: A >=90  B >=75  C >=50  D >=30  F <30
+
+The deterministic score never changes on an unchanged tree. The --review overlay
+(Architecture, Actionability, Non-obvious patterns) varies and is shown separately.
+EOF
+            exit 0
+            ;;
+        *)
+            PROJECT_DIR="$1"
+            shift
+            ;;
+    esac
+done
+
+PROJECT_DIR="${PROJECT_DIR:-.}"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required" >&2
+    exit 2
+fi
+
+# Optional LLM-axis ratings for the secondary "with review" grade.
+REVIEW_JSON='{}'
+if [ -n "$REVIEW_FILE" ]; then
+    if [ -f "$REVIEW_FILE" ] && jq -e . "$REVIEW_FILE" >/dev/null 2>&1; then
+        REVIEW_JSON=$(cat "$REVIEW_FILE")
+    else
+        echo "Error: --review file missing or not valid JSON: $REVIEW_FILE" >&2
+        exit 2
+    fi
+fi
+
+# Run a verifier in --json mode; tolerate its non-zero "issues found" exit and
+# its human stderr. Echo '{}' if it produced nothing parseable so jq stays happy.
+run_json() {
+    local script="$1"
+    shift
+    local out
+    out=$(bash "$SCRIPT_DIR/$script" "$PROJECT_DIR" --json "$@" 2>/dev/null || true)
+    if [ -n "$out" ] && printf '%s' "$out" | jq -e . >/dev/null 2>&1; then
+        printf '%s' "$out"
+    else
+        echo '{}'
+    fi
+}
+
+STRUCT_JSON=$(run_json validate-structure.sh)
+FRESH_JSON=$(run_json check-freshness.sh)
+CONTENT_JSON=$(run_json verify-content.sh)
+COMMANDS_JSON=$(run_json verify-commands.sh)
+
+# Spine = the files validate-structure reports (it already excludes vendored
+# example fixtures). Precompute a path -> line-count map for the Conciseness axis.
+mapfile -t SPINE < <(printf '%s' "$STRUCT_JSON" | jq -r '(.files // [])[].path')
+
+lines_pairs=()
+for path in "${SPINE[@]}"; do
+    full="$PROJECT_DIR/$path"
+    n=0
+    [ -f "$full" ] && n=$(wc -l < "$full" | tr -d ' ')
+    lines_pairs+=("$(jq -nc --arg p "$path" --argjson n "$n" '{key:$p,value:$n}')")
+done
+if [ "${#lines_pairs[@]}" -eq 0 ]; then
+    LINES_JSON='{}'
+else
+    LINES_JSON=$(printf '%s\n' "${lines_pairs[@]}" | jq -s 'from_entries')
+fi
+
+# --- Scoring (single jq pass; pure function of its inputs => reproducible) -----
+SCORING=$(jq -nc \
+    --argjson struct "$STRUCT_JSON" \
+    --argjson fresh "$FRESH_JSON" \
+    --argjson content "$CONTENT_JSON" \
+    --argjson commands "$COMMANDS_JSON" \
+    --argjson lines "$LINES_JSON" \
+    --argjson review "$REVIEW_JSON" \
+    '
+    def clamp(max): if . < 0 then 0 elif . > max then max else . end;
+    def grade(p): if p>=90 then "A" elif p>=75 then "B" elif p>=50 then "C" elif p>=30 then "D" else "F" end;
+    def frac(r): if r=="strong" then 1.0 elif r=="adequate" then 0.6 else 0.2 end;
+
+    ($fresh.files // [] | map({(.path): .}) | add // {}) as $fmap |
+    ($commands.summary // {passed:0,skipped:0,failed:0}) as $cmd |
+    (($cmd.passed // 0) + ($cmd.failed // 0)) as $cmdTotal |
+
+    [ ($struct.files // [])[] |
+      .path as $p | .role as $role |
+      (.errors // 0) as $se | (.warnings // 0) as $sw |
+
+      # Structure (25)
+      ((25 - $se*5 - $sw*2) | clamp(25)) as $structure |
+
+      # Currency (20)
+      ($fmap[$p]) as $fr |
+      ( if $fr == null then 8
+        elif $fr.status == "fresh" then 20
+        elif $fr.status == "unknown" then 8
+        else ( ($fr.commits_since // 0) as $c |
+               if $c <= 7 then 15 elif $c <= 14 then 11 elif $c <= 30 then 7 else 4 end )
+        end ) as $currency |
+
+      # Content (20) - issues attributed to this file
+      ( [ ($content.issues // [])[] | select(.file == $p) ] ) as $ci |
+      ( [ $ci[] | select(.severity=="ERROR") ] | length ) as $ce |
+      ( [ $ci[] | select(.severity=="WARN")  ] | length ) as $cw |
+      ((20 - $ce*5 - $cw*2) | clamp(20)) as $content_s |
+
+      # Conciseness (20) - by role, from line count
+      ($lines[$p] // 0) as $ln |
+      ( if $role == "root"
+        then ( if $ln<=50 then 20 elif $ln<=80 then 16 elif $ln<=150 then 10 else 5 end )
+        else ( if $ln<=150 then 20 elif $ln<=250 then 15 else 8 end )
+        end ) as $concise |
+
+      # Commands (15) - root only, and only if there are verifiable commands
+      ( if $role=="root" and $cmdTotal>0
+        then { applies:true, score: (($cmd.passed*15/$cmdTotal)|floor) }
+        else { applies:false, score:0 }
+        end ) as $commands_axis |
+
+      ( 25+20+20+20 + (if $commands_axis.applies then 15 else 0 end) ) as $maxApplicable |
+      ( $structure+$currency+$content_s+$concise + $commands_axis.score ) as $earned |
+      (($earned*100/$maxApplicable)|round) as $pct |
+
+      # Optional qualitative overlay (non-reproducible): blend agent-judged LLM
+      # axes (Architecture 10 / Actionability 8 / Non-obvious 7) into a secondary
+      # grade. Only present when --review supplied a rating for this path.
+      ($review[$p]) as $rv |
+      ( if $rv == null then null
+        else (frac($rv.architecture // "weak")*10
+            + frac($rv.actionability // "weak")*8
+            + frac($rv.non_obvious  // "weak")*7) end ) as $llm |
+      ( if $llm == null then null
+        else ((($earned + $llm) * 100 / ($maxApplicable + 25)) | round) end ) as $blended |
+
+      { path:$p, role:$role, percent:$pct, grade: grade($pct),
+        review: (if $rv == null then null
+                 else {ratings:$rv, blended_percent:$blended, blended_grade:grade($blended)} end),
+        axes: {
+          structure:   {score:$structure,   max:25},
+          currency:    {score:$currency,    max:20},
+          content:     {score:$content_s,   max:20},
+          conciseness: {score:$concise,     max:20},
+          commands:    (if $commands_axis.applies then {score:$commands_axis.score, max:15} else {score:null, max:null, note:"n/a (scoped / no verifiable commands)"} end)
+        }
+      }
+    ] | sort_by(.percent) as $files |
+    ( [ $files[] | select(.review != null) ] ) as $reviewed |
+    { schema:1,
+      summary: {
+        files: ($files|length),
+        average: (if ($files|length)>0 then (([$files[].percent]|add)/($files|length))|round else 0 end),
+        grade_counts: ($files | group_by(.grade) | map({(.[0].grade): length}) | add // {}),
+        reviewed: ($reviewed|length),
+        blended_average: (if ($reviewed|length)>0 then (([$reviewed[].review.blended_percent]|add)/($reviewed|length))|round else null end)
+      },
+      files: $files
+    }
+    ')
+
+if [ "$JSON" = true ]; then
+    printf '%s\n' "$SCORING" | jq .
+    exit 0
+fi
+
+# --- Human report (rendered from the deterministic scoring document) ----------
+printf '%s' "$SCORING" | jq -r '
+    "AGENTS.md Quality Report  -  " + (.summary.files|tostring) + " file(s), average "
+      + (.summary.average|tostring) + "/100   (worst-first)"
+      + (if .summary.blended_average != null then "; with-review avg ~" + (.summary.blended_average|tostring) else "" end),
+    "",
+    ( .files[] |
+      "  " + (.grade) + "  " + ((.percent|tostring)+"/100" | (. + (" " * (8 - (.|length)))))
+        + "  " + .path,
+      "       structure "  + (.axes.structure.score|tostring)  + "/25"
+        + "  currency "    + (.axes.currency.score|tostring)    + "/20"
+        + "  content "     + (.axes.content.score|tostring)     + "/20"
+        + "  conciseness " + (.axes.conciseness.score|tostring) + "/20"
+        + (if .axes.commands.score != null then "  commands " + (.axes.commands.score|tostring) + "/15" else "" end),
+      ( if .review != null
+        then "       with review: " + .review.blended_grade + " ~" + (.review.blended_percent|tostring)
+             + "/100  (non-reproducible)"
+        else empty end )
+    )
+'
+
+echo ""
+echo "Headline grades are deterministic (reproducible). Any 'with review' line is a"
+echo "qualitative LLM overlay (non-reproducible) - see references/quality-rubric.md."

--- a/skills/agent-rules/scripts/score-agents.sh
+++ b/skills/agent-rules/scripts/score-agents.sh
@@ -111,18 +111,17 @@ COMMANDS_JSON=$(run_json verify-commands.sh)
 # example fixtures). Precompute a path -> line-count map for the Conciseness axis.
 mapfile -t SPINE < <(printf '%s' "$STRUCT_JSON" | jq -r '(.files // [])[].path')
 
-lines_pairs=()
-for path in "${SPINE[@]}"; do
-    full="$PROJECT_DIR/$path"
-    n=0
-    [[ -f "$full" ]] && n=$(wc -l < "$full" | tr -d ' ')
-    lines_pairs+=("$(jq -nc --arg p "$path" --argjson n "$n" '{key:$p,value:$n}')")
-done
-if [[ "${#lines_pairs[@]}" -eq 0 ]]; then
-    LINES_JSON='{}'
-else
-    LINES_JSON=$(printf '%s\n' "${lines_pairs[@]}" | jq -s 'from_entries')
-fi
+# Build the path -> line-count map in a SINGLE jq pass (tab-separated stream)
+# rather than spawning jq once per file.
+LINES_JSON=$(
+    for path in "${SPINE[@]}"; do
+        full="$PROJECT_DIR/$path"
+        n=0
+        [[ -f "$full" ]] && n=$(wc -l < "$full" | tr -d ' ')
+        printf '%s\t%s\n' "$path" "$n"
+    done | jq -Rs 'split("\n") | map(select(. != "")) | map(split("\t"))
+                   | map({key: .[0], value: (.[1]|tonumber)}) | from_entries'
+)
 
 # --- Scoring (single jq pass; pure function of its inputs => reproducible) -----
 SCORING=$(jq -nc \

--- a/skills/agent-rules/scripts/validate-structure.sh
+++ b/skills/agent-rules/scripts/validate-structure.sh
@@ -192,7 +192,11 @@ check_scope_links() {
     local root_file="$1"
 
     if ! grep -q "## Index of scoped AGENTS.md" "$root_file"; then
-        return 0  # No index, skip check
+        # No scope index (thin root without scopes) -- nothing to check. Set an
+        # explicit status so a subsequent record_check does not reuse the
+        # previous check's LAST_STATUS/LAST_DETAIL in --json mode.
+        LAST_STATUS="pass"; LAST_DETAIL="No scope index (no scoped files to link)"
+        return 0
     fi
 
     # Extract links from scope index

--- a/skills/agent-rules/scripts/validate-structure.sh
+++ b/skills/agent-rules/scripts/validate-structure.sh
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR=""
 CHECK_FRESHNESS=false
 VERBOSE=false
+JSON=false
 
 # Parse flags
 while [[ $# -gt 0 ]]; do
@@ -21,6 +22,10 @@ while [[ $# -gt 0 ]]; do
             VERBOSE=true
             shift
             ;;
+        --json)
+            JSON=true
+            shift
+            ;;
         --help|-h)
             cat <<EOF
 Usage: validate-structure.sh [PROJECT_DIR] [OPTIONS]
@@ -30,6 +35,7 @@ Validate AGENTS.md structure compliance and optionally check freshness.
 Options:
   --check-freshness, -f  Also check if files are up to date with git commits
   --verbose, -v          Show detailed output
+  --json                 Emit machine-readable JSON on stdout (structure only)
   --help, -h             Show this help message
 
 Examples:
@@ -52,22 +58,43 @@ cd "$PROJECT_DIR" || exit 1
 ERRORS=0
 WARNINGS=0
 
+# --json state: each helper records the outcome of the just-run check so that
+# record_check can attach it to a per-file record. Default-path output is unchanged.
+LAST_STATUS=""
+LAST_DETAIL=""
+declare -A FILE_CHECKS_JSON=()
+declare -A FILE_ROLE=()
+
 error() {
     echo "❌ ERROR: $*"
     ((ERRORS+=1))
+    LAST_STATUS="fail"; LAST_DETAIL="$*"
 }
 
 warning() {
     echo "⚠️  WARNING: $*"
     ((WARNINGS+=1))
+    LAST_STATUS="warn"; LAST_DETAIL="$*"
 }
 
 success() {
     echo "✅ $*"
+    LAST_STATUS="pass"; LAST_DETAIL="$*"
 }
 
 info() {
     echo "ℹ️  $*"
+    LAST_STATUS="pass"; LAST_DETAIL="$*"
+}
+
+# Record the just-run check (LAST_STATUS/LAST_DETAIL) under a relative file path.
+# No-op unless --json; never writes to stdout.
+record_check() {
+    [ "$JSON" = true ] || return 0
+    local path="$1" name="$2" obj
+    obj=$(jq -nc --arg name "$name" --arg status "$LAST_STATUS" --arg detail "$LAST_DETAIL" \
+        '{name:$name,status:$status,detail:$detail}')
+    FILE_CHECKS_JSON["$path"]="${FILE_CHECKS_JSON["$path"]:-}${obj}"$'\n'
 }
 
 # Check if file has managed header
@@ -231,6 +258,12 @@ check_claude_symlink() {
     fi
 }
 
+# In JSON mode, route all human-readable output to /dev/null and reserve the
+# original stdout (fd 3) for the single JSON document emitted at the end.
+if [ "$JSON" = true ]; then
+    exec 3>&1 1>/dev/null
+fi
+
 # Main validation
 echo "Validating AGENTS.md structure in: $PROJECT_DIR"
 echo ""
@@ -242,10 +275,11 @@ if [ ! -f "$ROOT_FILE" ]; then
     error "Root AGENTS.md not found"
 else
     echo "=== Root AGENTS.md ==="
-    check_managed_header "$ROOT_FILE"
-    check_root_is_thin "$ROOT_FILE"
-    check_precedence_statement "$ROOT_FILE"
-    check_scope_links "$ROOT_FILE"
+    FILE_ROLE["AGENTS.md"]="root"
+    check_managed_header "$ROOT_FILE"; record_check "AGENTS.md" "managed_header"
+    check_root_is_thin "$ROOT_FILE"; record_check "AGENTS.md" "root_is_thin"
+    check_precedence_statement "$ROOT_FILE"; record_check "AGENTS.md" "precedence"
+    check_scope_links "$ROOT_FILE"; record_check "AGENTS.md" "scope_links"
     echo ""
 fi
 
@@ -262,6 +296,8 @@ ALL_AGENTS_FILES=$(find "$PROJECT_DIR" -name "AGENTS.md" \
 if [ -n "$ALL_AGENTS_FILES" ]; then
     while read -r file; do
         check_claude_symlink "$file"
+        sym_rel="${file#"$PROJECT_DIR"/}"; sym_rel="${sym_rel#./}"
+        record_check "$sym_rel" "claude_symlink"
     done <<< "$ALL_AGENTS_FILES"
 fi
 echo ""
@@ -279,10 +315,44 @@ if [ -n "$SCOPED_FILES" ]; then
     while read -r file; do
         rel_path="${file#"$PROJECT_DIR"/}"
         echo "Checking: $rel_path"
-        check_managed_header "$file"
-        check_scoped_sections "$file"
+        json_key="${rel_path#./}"
+        FILE_ROLE["$json_key"]="scoped"
+        check_managed_header "$file"; record_check "$json_key" "managed_header"
+        check_scoped_sections "$file"; record_check "$json_key" "required_sections"
         echo ""
     done <<< "$SCOPED_FILES"
+fi
+
+# Emit JSON document and exit before the human summary. JSON mode is structure-only
+# and deliberately does NOT run the --check-freshness shell-out below (score-agents
+# calls check-freshness.sh --json itself), keeping the two signals decoupled.
+if [ "$JSON" = true ]; then
+    json_files=()
+    if [ "${#FILE_CHECKS_JSON[@]}" -gt 0 ]; then
+        while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            checks_json=$(printf '%s' "${FILE_CHECKS_JSON[$path]}" | jq -s '.')
+            json_files+=("$(jq -nc \
+                --arg path "$path" \
+                --arg role "${FILE_ROLE[$path]:-scoped}" \
+                --argjson checks "$checks_json" \
+                '{path:$path,role:$role,
+                  errors:($checks|map(select(.status=="fail"))|length),
+                  warnings:($checks|map(select(.status=="warn"))|length),
+                  checks:$checks}')")
+        done < <(printf '%s\n' "${!FILE_CHECKS_JSON[@]}" | sort)
+    fi
+    if [ "${#json_files[@]}" -eq 0 ]; then
+        files_json='[]'
+    else
+        files_json=$(printf '%s\n' "${json_files[@]}" | jq -s '.')
+    fi
+    jq -nc \
+        --argjson files "$files_json" \
+        --argjson e "$ERRORS" \
+        --argjson w "$WARNINGS" \
+        '{script:"validate-structure",schema:1,summary:{errors:$e,warnings:$w},files:$files}' >&3
+    if [ "$ERRORS" -eq 0 ]; then exit 0; else exit 1; fi
 fi
 
 # Summary

--- a/skills/agent-rules/scripts/validate-structure.sh
+++ b/skills/agent-rules/scripts/validate-structure.sh
@@ -90,7 +90,7 @@ info() {
 # Record the just-run check (LAST_STATUS/LAST_DETAIL) under a relative file path.
 # No-op unless --json; never writes to stdout.
 record_check() {
-    [ "$JSON" = true ] || return 0
+    [[ "$JSON" = true ]] || return 0
     local path="$1" name="$2" obj
     obj=$(jq -nc --arg name "$name" --arg status "$LAST_STATUS" --arg detail "$LAST_DETAIL" \
         '{name:$name,status:$status,detail:$detail}')
@@ -260,7 +260,7 @@ check_claude_symlink() {
 
 # In JSON mode, route all human-readable output to /dev/null and reserve the
 # original stdout (fd 3) for the single JSON document emitted at the end.
-if [ "$JSON" = true ]; then
+if [[ "$JSON" = true ]]; then
     exec 3>&1 1>/dev/null
 fi
 
@@ -326,11 +326,11 @@ fi
 # Emit JSON document and exit before the human summary. JSON mode is structure-only
 # and deliberately does NOT run the --check-freshness shell-out below (score-agents
 # calls check-freshness.sh --json itself), keeping the two signals decoupled.
-if [ "$JSON" = true ]; then
+if [[ "$JSON" = true ]]; then
     json_files=()
-    if [ "${#FILE_CHECKS_JSON[@]}" -gt 0 ]; then
+    if [[ "${#FILE_CHECKS_JSON[@]}" -gt 0 ]]; then
         while IFS= read -r path; do
-            [ -z "$path" ] && continue
+            [[ -z "$path" ]] && continue
             checks_json=$(printf '%s' "${FILE_CHECKS_JSON[$path]}" | jq -s '.')
             json_files+=("$(jq -nc \
                 --arg path "$path" \
@@ -342,7 +342,7 @@ if [ "$JSON" = true ]; then
                   checks:$checks}')")
         done < <(printf '%s\n' "${!FILE_CHECKS_JSON[@]}" | sort)
     fi
-    if [ "${#json_files[@]}" -eq 0 ]; then
+    if [[ "${#json_files[@]}" -eq 0 ]]; then
         files_json='[]'
     else
         files_json=$(printf '%s\n' "${json_files[@]}" | jq -s '.')
@@ -352,7 +352,7 @@ if [ "$JSON" = true ]; then
         --argjson e "$ERRORS" \
         --argjson w "$WARNINGS" \
         '{script:"validate-structure",schema:1,summary:{errors:$e,warnings:$w},files:$files}' >&3
-    if [ "$ERRORS" -eq 0 ]; then exit 0; else exit 1; fi
+    if [[ "$ERRORS" -eq 0 ]]; then exit 0; else exit 1; fi
 fi
 
 # Summary

--- a/skills/agent-rules/scripts/verify-commands.sh
+++ b/skills/agent-rules/scripts/verify-commands.sh
@@ -633,7 +633,10 @@ done
 # parsing each stored value as JSON, else null).
 if [[ "$JSON" = true ]]; then
     if [[ "${#COMMAND_RESULTS[@]}" -gt 0 ]]; then
-        for cmd in "${!COMMAND_RESULTS[@]}"; do
+        # Iterate keys in SORTED order: associative-array key order is otherwise
+        # unspecified in Bash, which would make commands[] order vary run to run.
+        # read -r (not word-split) preserves command strings that contain spaces.
+        while IFS= read -r cmd; do
             stored="${COMMAND_RESULTS[$cmd]}"
             if entry=$(jq -nc --arg cmd "$cmd" --argjson detail "$stored" \
                 '{cmd:$cmd,detail:$detail}' 2>/dev/null); then
@@ -641,7 +644,7 @@ if [[ "$JSON" = true ]]; then
             else
                 JSON_CMDS+=("$(jq -nc --arg cmd "$cmd" '{cmd:$cmd,detail:null}')")
             fi
-        done
+        done < <(printf '%s\n' "${!COMMAND_RESULTS[@]}" | LC_ALL=C sort)
     fi
 
     if [[ "${#JSON_CMDS[@]}" -eq 0 ]]; then

--- a/skills/agent-rules/scripts/verify-commands.sh
+++ b/skills/agent-rules/scripts/verify-commands.sh
@@ -11,7 +11,47 @@ if ((BASH_VERSINFO[0] < 4)); then
     exit 1
 fi
 
-PROJECT_DIR="${1:-.}"
+PROJECT_DIR="."
+JSON=false
+
+# Parse flags. Preserves the original positional semantics (PROJECT_DIR="${1:-.}"):
+# the first non-flag argument becomes PROJECT_DIR, defaulting to "." when absent.
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --json)
+            JSON=true
+            shift
+            ;;
+        --help|-h)
+            cat <<EOF
+Usage: verify-commands.sh [PROJECT_DIR] [OPTIONS]
+
+Verify that commands documented in AGENTS.md actually exist (and optionally run).
+
+Options:
+  --json                Emit machine-readable JSON on stdout (human output suppressed)
+  --help, -h            Show this help message
+
+Environment variables:
+  VERBOSE=true          Show detailed [INFO] output on stderr
+  DRY_RUN=true          Skip writing the JSON sidecar and updating timestamps
+  SMOKE_TEST=true       Actually run safe commands (not just check existence)
+  TIMEOUT=SECONDS       Per-command timeout for smoke tests (default: 60)
+  OUTPUT_JSON=PATH      Sidecar results file (default: PROJECT_DIR/.agents/command-verification.json)
+
+Examples:
+  verify-commands.sh .                     # Verify commands in ./AGENTS.md
+  verify-commands.sh . --json              # Machine-readable JSON output
+EOF
+            exit 0
+            ;;
+        *)
+            PROJECT_DIR="$1"
+            shift
+            ;;
+    esac
+done
+
 AGENTS_FILE="$PROJECT_DIR/AGENTS.md"
 VERBOSE="${VERBOSE:-false}"
 DRY_RUN="${DRY_RUN:-false}"
@@ -50,6 +90,14 @@ if [ ! -f "$AGENTS_FILE" ]; then
 fi
 
 cd "$PROJECT_DIR"
+
+# In JSON mode, route all human-readable output to /dev/null and reserve the
+# original stdout (fd 3) for the single JSON document emitted at the end. This
+# keeps --json strictly additive: the default (no-flag) path is untouched.
+JSON_CMDS=()
+if [ "$JSON" = true ]; then
+    exec 3>&1 1>/dev/null
+fi
 
 echo "Verifying commands in $AGENTS_FILE..."
 echo ""
@@ -565,6 +613,10 @@ mapfile -t commands < <(extract_commands | sort -u)
 
 if [ ${#commands[@]} -eq 0 ]; then
     warn "No commands found in AGENTS.md"
+    if [ "$JSON" = true ]; then
+        jq -nc --argjson p "$PASSED" --argjson s "$SKIPPED" --argjson f "$FAILED" \
+            '{script:"verify-commands",schema:1,summary:{passed:$p,skipped:$s,failed:$f},commands:[]}' >&3
+    fi
     exit 0
 fi
 
@@ -574,6 +626,40 @@ echo ""
 for cmd in "${commands[@]}"; do
     [ -n "$cmd" ] && verify_command "$cmd"
 done
+
+# Emit JSON document (machine-readable) and exit before the human summary.
+# Summary counts come from the authoritative PASSED/SKIPPED/FAILED counters; the
+# commands[] array is built best-effort from COMMAND_RESULTS (iterating its keys,
+# parsing each stored value as JSON, else null).
+if [ "$JSON" = true ]; then
+    if [ "${#COMMAND_RESULTS[@]}" -gt 0 ]; then
+        for cmd in "${!COMMAND_RESULTS[@]}"; do
+            stored="${COMMAND_RESULTS[$cmd]}"
+            if entry=$(jq -nc --arg cmd "$cmd" --argjson detail "$stored" \
+                '{cmd:$cmd,detail:$detail}' 2>/dev/null); then
+                JSON_CMDS+=("$entry")
+            else
+                JSON_CMDS+=("$(jq -nc --arg cmd "$cmd" '{cmd:$cmd,detail:null}')")
+            fi
+        done
+    fi
+
+    if [ "${#JSON_CMDS[@]}" -eq 0 ]; then
+        arr_json='[]'
+    else
+        arr_json=$(printf '%s\n' "${JSON_CMDS[@]}" | jq -s '.')
+    fi
+
+    jq -nc \
+        --argjson items "$arr_json" \
+        --argjson p "$PASSED" \
+        --argjson s "$SKIPPED" \
+        --argjson f "$FAILED" \
+        '{script:"verify-commands",schema:1,summary:{passed:$p,skipped:$s,failed:$f},commands:$items}' >&3
+
+    if [ "$FAILED" -gt 0 ]; then exit 1; fi
+    exit 0
+fi
 
 echo ""
 echo "======================================"

--- a/skills/agent-rules/scripts/verify-commands.sh
+++ b/skills/agent-rules/scripts/verify-commands.sh
@@ -95,7 +95,7 @@ cd "$PROJECT_DIR"
 # original stdout (fd 3) for the single JSON document emitted at the end. This
 # keeps --json strictly additive: the default (no-flag) path is untouched.
 JSON_CMDS=()
-if [ "$JSON" = true ]; then
+if [[ "$JSON" = true ]]; then
     exec 3>&1 1>/dev/null
 fi
 
@@ -613,7 +613,7 @@ mapfile -t commands < <(extract_commands | sort -u)
 
 if [ ${#commands[@]} -eq 0 ]; then
     warn "No commands found in AGENTS.md"
-    if [ "$JSON" = true ]; then
+    if [[ "$JSON" = true ]]; then
         jq -nc --argjson p "$PASSED" --argjson s "$SKIPPED" --argjson f "$FAILED" \
             '{script:"verify-commands",schema:1,summary:{passed:$p,skipped:$s,failed:$f},commands:[]}' >&3
     fi
@@ -631,8 +631,8 @@ done
 # Summary counts come from the authoritative PASSED/SKIPPED/FAILED counters; the
 # commands[] array is built best-effort from COMMAND_RESULTS (iterating its keys,
 # parsing each stored value as JSON, else null).
-if [ "$JSON" = true ]; then
-    if [ "${#COMMAND_RESULTS[@]}" -gt 0 ]; then
+if [[ "$JSON" = true ]]; then
+    if [[ "${#COMMAND_RESULTS[@]}" -gt 0 ]]; then
         for cmd in "${!COMMAND_RESULTS[@]}"; do
             stored="${COMMAND_RESULTS[$cmd]}"
             if entry=$(jq -nc --arg cmd "$cmd" --argjson detail "$stored" \
@@ -644,7 +644,7 @@ if [ "$JSON" = true ]; then
         done
     fi
 
-    if [ "${#JSON_CMDS[@]}" -eq 0 ]; then
+    if [[ "${#JSON_CMDS[@]}" -eq 0 ]]; then
         arr_json='[]'
     else
         arr_json=$(printf '%s\n' "${JSON_CMDS[@]}" | jq -s '.')
@@ -657,7 +657,7 @@ if [ "$JSON" = true ]; then
         --argjson f "$FAILED" \
         '{script:"verify-commands",schema:1,summary:{passed:$p,skipped:$s,failed:$f},commands:$items}' >&3
 
-    if [ "$FAILED" -gt 0 ]; then exit 1; fi
+    if [[ "$FAILED" -gt 0 ]]; then exit 1; fi
     exit 0
 fi
 

--- a/skills/agent-rules/scripts/verify-content.sh
+++ b/skills/agent-rules/scripts/verify-content.sh
@@ -10,7 +10,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${1:-.}"
 VERBOSE=false
 FIX_MODE=false
+JSON=false
 EXIT_CODE=0
+# Relative path of the AGENTS.md currently being verified; captured into each
+# issue's "file" field in JSON mode. Empty => emitted as JSON null.
+CURRENT_FILE=""
 
 # Colors
 RED='\033[0;31m'
@@ -29,6 +33,10 @@ while [[ $# -gt 0 ]]; do
             FIX_MODE=true
             shift
             ;;
+        --json)
+            JSON=true
+            shift
+            ;;
         --help|-h)
             cat <<EOF
 Usage: verify-content.sh [PROJECT_DIR] [OPTIONS]
@@ -42,6 +50,7 @@ that need manual review or correction.
 Options:
   --verbose, -v     Show detailed comparison output
   --fix             Suggest fixes for common issues
+  --json            Emit machine-readable JSON on stdout (human output suppressed)
   --help, -h        Show this help message
 
 Verification checks:
@@ -71,6 +80,15 @@ done
 
 cd "$PROJECT_DIR"
 
+# In JSON mode, route all human-readable output to /dev/null and reserve the
+# original stdout (fd 3) for the single JSON document emitted at the end. This
+# keeps --json strictly additive: the default (no-flag) path is byte-for-byte
+# unchanged.
+JSON_ISSUES=()
+if [ "$JSON" = true ]; then
+    exec 3>&1 1>/dev/null
+fi
+
 echo "Verifying AGENTS.md content in: $(pwd)"
 echo ""
 
@@ -82,6 +100,13 @@ add_issue() {
     local message="$2"
     ISSUES+=("[$severity] $message")
     EXIT_CODE=1
+    # In JSON mode, also record a structured issue. "message" is stored without
+    # the [SEVERITY] prefix; "file" is the AGENTS.md currently under inspection
+    # (CURRENT_FILE), coerced to JSON null when empty.
+    if [ "$JSON" = true ]; then
+        JSON_ISSUES+=("$(jq -nc --arg sev "$severity" --arg msg "$message" --arg file "$CURRENT_FILE" \
+            '{severity:$sev,message:$msg,file:($file|if .=="" then null else . end)}')")
+    fi
 }
 
 log_check() {
@@ -138,6 +163,9 @@ extract_documented_scripts() {
 # ============================================================================
 
 echo "=== Verifying Root AGENTS.md ==="
+
+# Attribute root-section issues to the root AGENTS.md.
+CURRENT_FILE="AGENTS.md"
 
 if [ -f "AGENTS.md" ]; then
     echo -e "${GREEN}✓${NC} Root AGENTS.md exists"
@@ -198,6 +226,8 @@ SCOPED_FILES=$(find . -mindepth 2 -name "AGENTS.md" -not -path "./.git/*" 2>/dev
 for scoped_file in $SCOPED_FILES; do
     scope_dir=$(dirname "$scoped_file")
     scope_name=$(basename "$scope_dir")
+    # Attribute this iteration's issues to the scoped file (relative, no ./).
+    CURRENT_FILE="${scoped_file#./}"
     echo ""
     echo "Checking: $scoped_file"
 
@@ -268,6 +298,32 @@ for scoped_file in $SCOPED_FILES; do
 
     echo -e "${GREEN}✓${NC} Checked: $scoped_file"
 done
+
+# ============================================================================
+# JSON OUTPUT
+# ============================================================================
+
+# Emit the machine-readable JSON document (to the reserved fd 3) and exit using
+# the SAME EXIT_CODE the human path uses. summary.errors/warns are derived from
+# the assembled issues array; total mirrors ${#ISSUES[@]}.
+if [ "$JSON" = true ]; then
+    if [ "${#JSON_ISSUES[@]}" -eq 0 ]; then
+        issues_json='[]'
+    else
+        issues_json=$(printf '%s\n' "${JSON_ISSUES[@]}" | jq -s '.')
+    fi
+    jq -nc \
+        --argjson items "$issues_json" \
+        --argjson total "${#ISSUES[@]}" \
+        '{script:"verify-content",schema:1,
+          summary:{
+            errors:([$items[]|select(.severity=="ERROR")]|length),
+            warns:([$items[]|select(.severity=="WARN")]|length),
+            total:$total
+          },
+          issues:$items}' >&3
+    exit $EXIT_CODE
+fi
 
 # ============================================================================
 # SUMMARY

--- a/skills/agent-rules/scripts/verify-content.sh
+++ b/skills/agent-rules/scripts/verify-content.sh
@@ -240,7 +240,9 @@ for scoped_file in $SCOPED_FILES; do
         # just the scope dir, so search the whole project for its basename and
         # only flag when it exists NOWHERE. This avoids false positives from the
         # previous narrow 3-location check.
-        if ! find . -name "$doc_file" -not -path './.git/*' -print -quit 2>/dev/null | grep -q .; then
+        if ! find . -name "$doc_file" \
+                -not -path './.git/*' -not -path '*/node_modules/*' -not -path '*/vendor/*' \
+                -print -quit 2>/dev/null | grep -q .; then
             # Special handling for common false positives
             case "$doc_file" in
                 *.json|*.md|*.yml|*.yaml)

--- a/skills/agent-rules/scripts/verify-content.sh
+++ b/skills/agent-rules/scripts/verify-content.sh
@@ -85,7 +85,7 @@ cd "$PROJECT_DIR"
 # keeps --json strictly additive: the default (no-flag) path is byte-for-byte
 # unchanged.
 JSON_ISSUES=()
-if [ "$JSON" = true ]; then
+if [[ "$JSON" = true ]]; then
     exec 3>&1 1>/dev/null
 fi
 
@@ -103,7 +103,7 @@ add_issue() {
     # In JSON mode, also record a structured issue. "message" is stored without
     # the [SEVERITY] prefix; "file" is the AGENTS.md currently under inspection
     # (CURRENT_FILE), coerced to JSON null when empty.
-    if [ "$JSON" = true ]; then
+    if [[ "$JSON" = true ]]; then
         JSON_ISSUES+=("$(jq -nc --arg sev "$severity" --arg msg "$message" --arg file "$CURRENT_FILE" \
             '{severity:$sev,message:$msg,file:($file|if .=="" then null else . end)}')")
     fi
@@ -306,8 +306,8 @@ done
 # Emit the machine-readable JSON document (to the reserved fd 3) and exit using
 # the SAME EXIT_CODE the human path uses. summary.errors/warns are derived from
 # the assembled issues array; total mirrors ${#ISSUES[@]}.
-if [ "$JSON" = true ]; then
-    if [ "${#JSON_ISSUES[@]}" -eq 0 ]; then
+if [[ "$JSON" = true ]]; then
+    if [[ "${#JSON_ISSUES[@]}" -eq 0 ]]; then
         issues_json='[]'
     else
         issues_json=$(printf '%s\n' "${JSON_ISSUES[@]}" | jq -s '.')

--- a/skills/agent-rules/scripts/verify-content.sh
+++ b/skills/agent-rules/scripts/verify-content.sh
@@ -119,8 +119,12 @@ verify_makefile_target() {
 
 extract_documented_files() {
     local agents_file="$1"
-    # Extract file references like `filename.sh`, `filename.py`, etc.
-    grep -oE '\`[a-zA-Z0-9_-]+\.(sh|py|go|php|ts|js|json)\`' "$agents_file" 2>/dev/null | tr -d '`' | sort -u || true
+    # Extract file references inside markdown code spans, e.g. `filename.sh`.
+    # NOTE: the delimiters must be LITERAL backticks. A previous version used
+    # \` which GNU grep interprets as the "start of buffer" anchor, so this
+    # check silently matched nothing.
+    # shellcheck disable=SC2016  # Literal backticks are intended (markdown code spans), no expansion wanted
+    grep -oE '`[a-zA-Z0-9_-]+\.(sh|py|go|php|ts|js|json)`' "$agents_file" 2>/dev/null | tr -d '`' | sort -u || true
 }
 
 extract_documented_scripts() {
@@ -140,7 +144,12 @@ if [ -f "AGENTS.md" ]; then
 
     # Check documented make targets
     log_check "Makefile targets"
-    DOCUMENTED_TARGETS=$(grep -oE 'make [a-z_-]+' AGENTS.md | sed 's/make //' | sort -u)
+    # `|| true`: with `set -o pipefail`, a no-match grep makes this pipeline exit
+    # non-zero, which under `set -e` aborts the entire script here in the root
+    # section -- so the scoped-file loop below never runs. Tolerating the
+    # non-zero (as MODULE_COUNTS/SCRIPT_COUNTS already do) lets verification
+    # continue. Pre-existing bug: AGENTS.md without 'make ' commands aborted early.
+    DOCUMENTED_TARGETS=$(grep -oE 'make [a-z_-]+' AGENTS.md | sed 's/make //' | sort -u || true)
     for target in $DOCUMENTED_TARGETS; do
         verify_makefile_target "$target" || true
     done
@@ -197,8 +206,11 @@ for scoped_file in $SCOPED_FILES; do
     DOCUMENTED=$(extract_documented_files "$scoped_file")
 
     for doc_file in $DOCUMENTED; do
-        # Check if file exists relative to scope or project root
-        if [ ! -f "${scope_dir}/${doc_file}" ] && [ ! -f "./${doc_file}" ] && [ ! -f "scripts/${doc_file}" ]; then
+        # A documented file may live anywhere in the tree (src/, app/, ...), not
+        # just the scope dir, so search the whole project for its basename and
+        # only flag when it exists NOWHERE. This avoids false positives from the
+        # previous narrow 3-location check.
+        if ! find . -name "$doc_file" -not -path './.git/*' -print -quit 2>/dev/null | grep -q .; then
             # Special handling for common false positives
             case "$doc_file" in
                 *.json|*.md|*.yml|*.yaml)


### PR DESCRIPTION
## Summary

Improvements to the `agent-rules` skill drawn from comparing it against Anthropic's official `claude-md-management` plugin. Adds a **reproducible quality grade** for AGENTS.md files and an **anti-bloat content guide** — and surfaces three pre-existing bugs found along the way.

## What's new

### Reproducible quality grading — `scripts/score-agents.sh`
Aggregates the four verifier scripts into a 0–100 letter grade per AGENTS.md file (A–F), ranked worst-first. Five script-measured axes: Structure 25 · Currency 20 · Content 20 · Commands 15 (root) · Conciseness 20. Deterministic — no model call, CI-friendly.

Optional `--review FILE` adds a clearly-labelled, **non-reproducible** "with review" grade from agent-judged LLM axes (Architecture / Actionability / Non-obvious patterns) **without moving the deterministic headline**. See `references/quality-rubric.md`.

### `--json` on the four verifiers
`validate-structure`, `check-freshness`, `verify-content`, `verify-commands` each gained a `--json` mode. **Strictly additive** — default human output unchanged (verified byte-identical on the two scripts with no other changes).

### Content anti-patterns (`references/verification-guide.md`)
A "What NOT to Put in a Root AGENTS.md" table + four bad→good compression examples, scoped to always-loaded root content.

## ⚠️ Pre-existing bugs fixed (behavior changes — isolated in commit 1, revertable on their own)

1. `check-freshness.sh` aborted after the **first** stale/unknown file under `set -e` (1 of N processed; forced `validate-structure --check-freshness` to always warn).
2. `verify-content.sh` aborted in the root section when AGENTS.md had no `make ` targets (no-match grep under pipefail) → scoped loop never ran.
3. `verify-content.sh`'s generic "documented file exists" check used a backslash-escaped backtick in grep, which GNU grep treats as a buffer anchor → **never matched anything**. Fixed to a literal backtick + tree-wide existence lookup.

These now process **every** AGENTS.md file; default human output is otherwise unchanged.

## Testing

- shellcheck clean on all changed/new scripts (`verify-commands` carries a pre-existing info-level SC2016, unchanged).
- All four verifiers: valid + reproducible `--json`; byte-identical defaults on the two untouched scripts.
- `score-agents`: deterministic & reproducible; `--review` proven not to move the headline; Content & Commands deductions proven to fire on a fixture.
- markdownlint 0 errors; all scripts `bash -n` clean.

## Notes

- `score-agents`/`validate-structure` walk the whole tree (don't honour `.gitignore`) — point at a clean root for a clean grade (documented in `scripts-guide.md`).
- Currency axis can shift within a day for a file dated *today* (git bare-date `--since`) — documented.
