### PR TITLE
feat: make new-repo scaffolding an explicit When-to-Use trigger

### DIFF
--- a/evals/evals.json
+++ b/evals/evals.json
@@ -17,7 +17,7 @@
       "id": 3,
       "name": "scaffold-includes-agents-md",
       "prompt": "Scaffold a brand-new extension repository: composer.json, CI workflow, test runner. What belongs in the initial commits?",
-      "expected_output": "AGENTS.md (plus CLAUDE.md/GEMINI.md symlinks) generated via detect -> extract -> generate -> verify belongs in the initial scaffold commits, not deferred - the scaffolding session holds every fact, while retrofitting later requires a full re-verification pass against a codebase no longer in anyone's context."
+      "expected_output": "AGENTS.md (plus CLAUDE.md/GEMINI.md symlinks), generated via detect -> extract -> generate -> verify, belongs in the initial scaffold commits, not deferred - the scaffolding session holds every fact, while retrofitting later requires a full re-verification pass against a codebase no longer in anyone's context."
     }
   ]
 }

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -12,6 +12,12 @@
       "name": "detect-hooks-missing",
       "prompt": "I'm starting work on /home/cybot/projects/assetpicker/main/ — are git hooks configured?",
       "expected_output": "Should detect NO hook framework and suggest adding one"
+    },
+    {
+      "id": 3,
+      "name": "scaffold-includes-agents-md",
+      "prompt": "Scaffold a brand-new extension repository: composer.json, CI workflow, test runner. What belongs in the initial commits?",
+      "expected_output": "AGENTS.md (plus CLAUDE.md/GEMINI.md symlinks) generated via detect -> extract -> generate -> verify belongs in the initial scaffold commits, not deferred - the scaffolding session holds every fact, while retrofitting later requires a full re-verification pass against a codebase no longer in anyone's context."
     }
   ]
 }

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -17,8 +17,9 @@ Generate and maintain AGENTS.md files following the [agents.md convention](https
 ## When to Use
 
 - Creating or updating AGENTS.md for new/existing projects
+- **Scaffolding a new repository** — ship AGENTS.md with the initial commits; retrofitting later needs full re-verification
 - Standardizing agent documentation across repositories
-- Checking if AGENTS.md files are current with recent code changes
+- Checking AGENTS.md freshness after code changes
 - Onboarding AI agents to an unfamiliar codebase
 
 ## Scripts
@@ -77,9 +78,9 @@ Root: `assets/root-thin.md` (default) or `root-verbose.md`. Scoped: `assets/scop
 
 ## Supported Projects
 
-Go, PHP (Composer/Laravel/Symfony/TYPO3/Oro), TypeScript (React/Next/Vue/Node), Python (pip/poetry/ruff/mypy), Skill repos, Hybrid (multi-stack with auto-scoping).
+Go, PHP (Composer/Laravel/Symfony/TYPO3/Oro), TypeScript (React/Next/Vue/Node), Python (pip/poetry/ruff/mypy), Skill repos, Hybrid (auto-scoping).
 
 ## See Also
 
-- [`agent-harness-skill`](https://github.com/netresearch/agent-harness-skill) — broader agent-readiness harness (CI verification, enforcement).
-- [`skill-repo-skill`](https://github.com/netresearch/skill-repo-skill) — skill-repo structure (plugin.json, split licensing, release workflows).
+- [`agent-harness-skill`](https://github.com/netresearch/agent-harness-skill) — agent-readiness harness (CI enforcement).
+- [`skill-repo-skill`](https://github.com/netresearch/skill-repo-skill) — skill-repo structure (plugin.json, licensing, releases).


### PR DESCRIPTION
From a live retro (netresearch/t3x-nr-repurpose, 2026-06-12): the repo lived its entire build — 143 commits, 6 implementation plans, a first tagged release — without an AGENTS.md, and got one only after the missing docs caused friction (an agent fought unprovisioned test suites the docs would have flagged). A second scaffolded repo (website-spec-checker) shows the same gap.

Root cause: the skill lists 'new projects' as a use case, but nothing frames repo *creation* as the moment to run it — and the scaffolding agent never feels the gap (it has full context; the cost lands exclusively on later sessions). New explicit trigger: **scaffolding a new repository — ship AGENTS.md with the initial commits; retrofitting later needs full re-verification.**

SKILL.md stays under the 500-word cap (499) by trimming the See Also / Supported Projects phrasing. Eval 3 added covering the scenario.