### PR TITLE
chore(release): v3.13.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-rules",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "repository": "https://github.com/netresearch/agent-rules-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, jq 1.7+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.13.0"
+  version: "3.13.1"
   repository: https://github.com/netresearch/agent-rules-skill
 allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
 ---


### PR DESCRIPTION
Release v3.13.1 (bump from v3.13.0): plugin.json + 1 SKILL.md version(s).