### PR TITLE
fix(skill): link orphan reference feedback-memory-schema.md from SKILL.md

### DIFF
--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -62,15 +62,16 @@ Use `--update` to preserve human-curated content outside `<!-- GENERATED -->` ma
 
 | File | Contents |
 |------|----------|
-| [`verification-guide.md`](references/verification-guide.md) | Verification steps, design principles, anti-bloat |
+| [`verification-guide.md`](references/verification-guide.md) | Verification steps, anti-bloat |
 | [`scripts-guide.md`](references/scripts-guide.md) | Script options, validation checklist |
-| [`quality-rubric.md`](references/quality-rubric.md) | Quality grading rubric |
+| [`quality-rubric.md`](references/quality-rubric.md) | Grading rubric |
 | [`ai-tool-compatibility.md`](references/ai-tool-compatibility.md) | 16-agent compatibility matrix |
 | [`output-structure.md`](references/output-structure.md) | Root/scoped sections |
-| [`git-hooks-setup.md`](references/git-hooks-setup.md) | Hook framework detection and setup |
+| [`git-hooks-setup.md`](references/git-hooks-setup.md) | Hook framework setup |
 | [`examples/`](references/examples/) | Complete examples |
-| [`ai-contribution-guidelines.md`](references/ai-contribution-guidelines.md) | "3 Cs" framework for AI contributions |
+| [`ai-contribution-guidelines.md`](references/ai-contribution-guidelines.md) | "3 Cs" AI-contribution framework |
 | [`directory-coverage.md`](references/directory-coverage.md) | Scoped-file coverage rationale |
+| [`feedback-memory-schema.md`](references/feedback-memory-schema.md) | Approved-learning file format |
 
 ## Templates
 


### PR DESCRIPTION
Implements A21 for this repo (closes #66; part of the value-gate epic netresearch/skill-repo-skill#142).

feedback-memory-schema.md — the retro→agent-rules contract for approved-learning files — was reachable only via two sibling references, never from SKILL.md, so a model reading the skill could not discover it (audit-skills.sh ORPHAN finding, verified).

- Added to the SKILL.md reference table: `feedback-memory-schema.md | Approved-learning file format`
- Word cap held by trimming three verbose table cells (verification-guide, quality-rubric, git-hooks-setup, ai-contribution-guidelines descriptions): 499/500 words
- audit-skills.sh now reports no orphans for this skill