### PR TITLE
fix(examples): SHA-pin actions/checkout in example workflow

### DIFF
--- a/skills/agent-rules/assets/example-workflows/validate-agents.yml
+++ b/skills/agent-rules/assets/example-workflows/validate-agents.yml
@@ -24,7 +24,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check AGENTS.md exists
         run: |


### PR DESCRIPTION
Unblocks SAST for every open PR (currently failing on #67 without any related diff).

The opengrep community ruleset (fetched live via `--config auto`) added `github-actions-mutable-action-tag`, which flags the mutable `actions/checkout@v4` in `skills/agent-rules/assets/example-workflows/validate-agents.yml`. Last green SAST run was 2026-06-27 with the same pinned opengrep v1.19.0 — the rule change alone broke the gate.

- Pinned to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0` (latest release; tag SHA verified via GitHub API)
- Only occurrence in the example-workflows dir (grep-verified)
- Local verification with the CI's exact binary + config: 0 findings, exit 0
- The two long-standing nosemgrep suppressions (ifs-tampering, wildcard-cors) still hold and are untouched