### PR TITLE
chore(release): v3.13.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-rules",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "repository": "https://github.com/netresearch/agent-rules-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, jq 1.7+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.13.1"
+  version: "3.13.2"
   repository: https://github.com/netresearch/agent-rules-skill
 allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
 ---


### PR DESCRIPTION
- fix(skill): link orphan reference feedback-memory-schema.md from SKILL.md (https://github.com/netresearch/agent-rules-skill/pull/67)
- fix(examples): SHA-pin actions/checkout in example workflow (https://github.com/netresearch/agent-rules-skill/pull/68)
- bump plugin.json and SKILL.md metadata.version to 3.13.2