### PR TITLE
feat(manifest): add Agent Plugins 1.0.0 portable manifest

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "agent-rules",
+  "version": "3.13.2",
+  "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
+  "author": {
+    "name": "Netresearch DTT GmbH",
+    "url": "https://www.netresearch.de"
+  },
+  "repository": "https://github.com/netresearch/agent-rules-skill",
+  "license": "(MIT AND CC-BY-SA-4.0)"
+}


### PR DESCRIPTION
Adds the root `plugin.json` required by [Agent Plugins 1.0.0](https://agent-plugins.org/specification), so this plugin loads in conformant clients (Cursor, Copilot, …) and not only in Claude Code.

- Values are copied verbatim from `.claude-plugin/plugin.json` — nothing changes for Claude Code, which reads its own manifest and ignores this file.
- The portable schema is closed, so `skills`/`agents`/`support` stay in the Claude manifest.
- `skills/<name>/SKILL.md` already matches what Agent Plugins clients discover; no layout change.

From here on the root manifest is the source of truth for name, version, description, author, homepage, repository, license and keywords. `skill-repo-skill`'s `sync-plugin-manifest.sh` projects it into `.claude-plugin/plugin.json` and CI checks the parity — see [netresearch/skill-repo-skill#202](https://github.com/netresearch/skill-repo-skill/pull/202).