### PR TITLE
fix(agent-rules): case-tolerant scope-index match and @AGENTS.md import files

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -26,4 +26,4 @@ jobs:
     permissions:
       contents: read
     with:
-      check-cmd: bash skills/agent-rules/scripts/tests/test-scope-index-heading.sh
+      check-cmd: bash skills/agent-rules/scripts/tests/test-scope-index-heading.sh && bash skills/agent-rules/scripts/tests/test-claude-import-file.sh

--- a/skills/agent-rules/scripts/generate-agents.sh
+++ b/skills/agent-rules/scripts/generate-agents.sh
@@ -17,8 +17,11 @@ SKILL_DIR="$(dirname "$SCRIPT_DIR")"
 TEMPLATE_DIR="$SKILL_DIR/assets"
 
 # Source helper libraries
+# shellcheck disable=SC1091 # libs are shellchecked individually by the same hook
 source "$SCRIPT_DIR/lib/template.sh"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/summary.sh"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/config-root.sh"
 
 # Default options
@@ -1975,115 +1978,6 @@ else
                 scope_vars[SCOPE_GOLDEN_SAMPLES]=$(generate_scope_golden_samples "$SCOPE_PATH" "$cli_ext")
                 ;;
 
-            "backend-python")
-                scope_vars[PYTHON_VERSION]="$VERSION"
-                BUILD_TOOL=$(echo "$PROJECT_INFO" | jq -r '.build_tool')
-                scope_vars[PACKAGE_MANAGER]="$BUILD_TOOL"
-                scope_vars[ENV_VARS]="See .env or .env.example"
-
-                # Extract commands from detected commands
-                scope_vars[INSTALL_CMD]=$(echo "$COMMANDS" | jq -r '.install // empty')
-                scope_vars[LINT_CMD]=$(echo "$COMMANDS" | jq -r '.lint // empty')
-                scope_vars[FORMAT_CMD]=$(echo "$COMMANDS" | jq -r '.format // empty')
-                scope_vars[TEST_CMD]=$(echo "$COMMANDS" | jq -r '.test // empty')
-                scope_vars[TYPECHECK_CMD]=$(echo "$COMMANDS" | jq -r '.typecheck // empty')
-                scope_vars[BUILD_CMD]=$(echo "$COMMANDS" | jq -r '.build // empty')
-
-                # Set defaults based on build tool
-                case "$BUILD_TOOL" in
-                    "poetry")
-                        [ -z "${scope_vars[INSTALL_CMD]}" ] && scope_vars[INSTALL_CMD]="poetry install"
-                        [ -z "${scope_vars[LINT_CMD]}" ] && scope_vars[LINT_CMD]="poetry run ruff check ."
-                        [ -z "${scope_vars[FORMAT_CMD]}" ] && scope_vars[FORMAT_CMD]="poetry run ruff format ."
-                        [ -z "${scope_vars[TEST_CMD]}" ] && scope_vars[TEST_CMD]="poetry run pytest"
-                        scope_vars[VENV_CMD]="poetry shell"
-                        ;;
-                    "pip"|"uv")
-                        [ -z "${scope_vars[INSTALL_CMD]}" ] && scope_vars[INSTALL_CMD]="pip install -e ."
-                        [ -z "${scope_vars[LINT_CMD]}" ] && scope_vars[LINT_CMD]="ruff check ."
-                        [ -z "${scope_vars[FORMAT_CMD]}" ] && scope_vars[FORMAT_CMD]="ruff format ."
-                        [ -z "${scope_vars[TEST_CMD]}" ] && scope_vars[TEST_CMD]="pytest"
-                        scope_vars[VENV_CMD]="python -m venv .venv && source .venv/bin/activate"
-                        ;;
-                    *)
-                        scope_vars[VENV_CMD]="python -m venv .venv && source .venv/bin/activate"
-                        ;;
-                esac
-
-                # Detect framework for conventions
-                FRAMEWORK=$(echo "$PROJECT_INFO" | jq -r '.framework')
-                case "$FRAMEWORK" in
-                    "django")
-                        scope_vars[FRAMEWORK_CONVENTIONS]="- Follow Django conventions (apps, models, views)
-- Use Django ORM, avoid raw SQL"
-                        scope_vars[FRAMEWORK_DOCS]="https://docs.djangoproject.com"
-                        ;;
-                    "fastapi")
-                        scope_vars[FRAMEWORK_CONVENTIONS]="- Use Pydantic models for validation
-- Async handlers where appropriate"
-                        scope_vars[FRAMEWORK_DOCS]="https://fastapi.tiangolo.com"
-                        ;;
-                    "flask")
-                        scope_vars[FRAMEWORK_CONVENTIONS]="- Use Blueprints for modular design
-- Flask-SQLAlchemy for database"
-                        scope_vars[FRAMEWORK_DOCS]="https://flask.palletsprojects.com"
-                        ;;
-                    *)
-                        scope_vars[FRAMEWORK_CONVENTIONS]=""
-                        scope_vars[FRAMEWORK_DOCS]=""
-                        ;;
-                esac
-                scope_vars[HOUSE_RULES]=""
-                ;;
-
-            "backend-typescript")
-                scope_vars[NODE_VERSION]="$VERSION"
-                BUILD_TOOL=$(echo "$PROJECT_INFO" | jq -r '.build_tool')
-                scope_vars[PACKAGE_MANAGER]="$BUILD_TOOL"
-                scope_vars[ENV_VARS]="See .env or .env.example"
-
-                # Extract commands from detected commands
-                scope_vars[INSTALL_CMD]="$BUILD_TOOL install"
-                scope_vars[LINT_CMD]=$(echo "$COMMANDS" | jq -r '.lint // empty')
-                scope_vars[FORMAT_CMD]=$(echo "$COMMANDS" | jq -r '.format // empty')
-                scope_vars[TEST_CMD]=$(echo "$COMMANDS" | jq -r '.test // empty')
-                scope_vars[TYPECHECK_CMD]=$(echo "$COMMANDS" | jq -r '.typecheck // empty')
-                scope_vars[BUILD_CMD]=$(echo "$COMMANDS" | jq -r '.build // empty')
-                scope_vars[DEV_CMD]=$(echo "$COMMANDS" | jq -r '.dev // empty')
-
-                # Set defaults based on package manager
-                [ -z "${scope_vars[LINT_CMD]}" ] && scope_vars[LINT_CMD]="$BUILD_TOOL run lint"
-                [ -z "${scope_vars[FORMAT_CMD]}" ] && scope_vars[FORMAT_CMD]="$BUILD_TOOL run format"
-                [ -z "${scope_vars[TEST_CMD]}" ] && scope_vars[TEST_CMD]="$BUILD_TOOL test"
-                [ -z "${scope_vars[TYPECHECK_CMD]}" ] && scope_vars[TYPECHECK_CMD]="$BUILD_TOOL run typecheck"
-                [ -z "${scope_vars[BUILD_CMD]}" ] && scope_vars[BUILD_CMD]="$BUILD_TOOL run build"
-                [ -z "${scope_vars[DEV_CMD]}" ] && scope_vars[DEV_CMD]="$BUILD_TOOL run dev"
-
-                # Detect framework
-                FRAMEWORK=$(echo "$PROJECT_INFO" | jq -r '.framework')
-                case "$FRAMEWORK" in
-                    "express")
-                        scope_vars[FRAMEWORK_CONVENTIONS]="- Use middleware pattern
-- Async error handling with express-async-handler"
-                        scope_vars[FRAMEWORK_DOCS]="https://expressjs.com"
-                        ;;
-                    "nestjs")
-                        scope_vars[FRAMEWORK_CONVENTIONS]="- Use decorators and modules
-- Dependency injection via constructors"
-                        scope_vars[FRAMEWORK_DOCS]="https://docs.nestjs.com"
-                        ;;
-                    "fastify")
-                        scope_vars[FRAMEWORK_CONVENTIONS]="- Use schema validation
-- Plugin architecture"
-                        scope_vars[FRAMEWORK_DOCS]="https://www.fastify.io/docs"
-                        ;;
-                    *)
-                        scope_vars[FRAMEWORK_CONVENTIONS]=""
-                        scope_vars[FRAMEWORK_DOCS]=""
-                        ;;
-                esac
-                scope_vars[HOUSE_RULES]=""
-                ;;
 
             "testing")
                 set_scope_if_present TEST_CMD "$(echo "$SCOPE_COMMANDS" | jq -r '.test // empty')"
@@ -2384,10 +2278,30 @@ else
             echo "✅ Created: $SCOPE_FILE"
         fi
 
-        # Create subdirectory symlinks for cross-agent compatibility
+        # Create subdirectory symlinks for cross-agent compatibility.
+        # Documentation/ is symlink-hostile: the TYPO3 docs renderer lists it
+        # via Flysystem, which aborts on ANY symbolic link (#82). Emit a
+        # regular @AGENTS.md import file there instead (both Claude Code and
+        # Gemini CLI support the @file import syntax).
         if [ "$CREATE_SYMLINKS" = true ]; then
             for symlink_name in CLAUDE.md GEMINI.md; do
                 SYMLINK_FILE="$PROJECT_DIR/$SCOPE_PATH/$symlink_name"
+                if [ "$(basename "$SCOPE_PATH")" = "Documentation" ]; then
+                    if [ -f "$SYMLINK_FILE" ] && [ ! -L "$SYMLINK_FILE" ] && [ "$FORCE" = false ]; then
+                        log "$SCOPE_PATH/$symlink_name already exists (regular file), skipping (use --force to replace)"
+                        continue
+                    fi
+                    if [ "$DRY_RUN" = true ]; then
+                        echo "[DRY-RUN] Would write import file: $SYMLINK_FILE (@AGENTS.md)"
+                    else
+                        rm -f "$SYMLINK_FILE"
+                        printf '%s\n\n%s\n' \
+                            '<!-- Regular file, not a symlink: the TYPO3 docs renderer (Flysystem) rejects symbolic links inside Documentation/. -->' \
+                            '@AGENTS.md' > "$SYMLINK_FILE"
+                        echo "   ↳ Import file: $SCOPE_PATH/$symlink_name (@AGENTS.md, symlink-hostile directory)"
+                    fi
+                    continue
+                fi
                 if [ -L "$SYMLINK_FILE" ] || [ ! -e "$SYMLINK_FILE" ]; then
                     if [ "$DRY_RUN" = true ]; then
                         echo "[DRY-RUN] Would symlink: $SYMLINK_FILE → AGENTS.md"

--- a/skills/agent-rules/scripts/tests/test-claude-import-file.sh
+++ b/skills/agent-rules/scripts/tests/test-claude-import-file.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Regression test for CLAUDE.md import-file handling (issue #82).
+#
+# The TYPO3 docs renderer lists Documentation/ via Flysystem, which aborts on
+# any symbolic link, so a CLAUDE.md -> AGENTS.md symlink there breaks docs CI.
+# generate-agents.sh must emit a regular "@AGENTS.md" import file for
+# Documentation/ scopes, and validate-structure.sh must accept that file as
+# fully valid, while still warning on other regular CLAUDE.md files.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(dirname "$SCRIPT_DIR")"
+GENERATE="$SCRIPTS_DIR/generate-agents.sh"
+VALIDATE="$SCRIPTS_DIR/validate-structure.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "❌ FAIL: $1"; exit 1; }
+pass() { echo "✅ PASS: $1"; }
+
+# PHP fixture with a Documentation/ scope (>=3 RST files) and enough source
+# files that generate-agents.sh emits a root plus scoped files.
+FX="$WORK/php-docs"
+mkdir -p "$FX/src" "$FX/Documentation"
+cat > "$FX/composer.json" <<'JSON'
+{ "name": "acme/fixture", "require": { "php": "^8.2" }, "scripts": { "test": "phpunit" } }
+JSON
+# detect-scopes.sh needs MIN_FILES=5 source files for an src scope.
+for i in 1 2 3 4 5; do printf '<?php\nclass C%s {}\n' "$i" > "$FX/src/C$i.php"; done
+for i in 1 2 3; do printf 'Chapter %s\n=========\n' "$i" > "$FX/Documentation/Ch$i.rst"; done
+git -C "$FX" init -q
+git -C "$FX" -c user.email=t@t.t -c user.name=t add -A
+git -C "$FX" -c user.email=t@t.t -c user.name=t commit -qm init
+
+# --- Test 1: generator emits an import FILE, not a symlink, in Documentation/
+bash "$GENERATE" "$FX" --style=thin >/dev/null 2>&1 || fail "generate-agents.sh errored"
+[ -f "$FX/Documentation/AGENTS.md" ] \
+    || fail "fixture did not produce a scoped Documentation/AGENTS.md (scope not detected; fix the fixture)"
+[ -e "$FX/Documentation/CLAUDE.md" ] || fail "no Documentation/CLAUDE.md generated"
+if [ -L "$FX/Documentation/CLAUDE.md" ]; then
+    fail "Documentation/CLAUDE.md is a symlink -- breaks TYPO3 docs rendering (#82)"
+fi
+grep -qE '^@AGENTS\.md[[:space:]]*$' "$FX/Documentation/CLAUDE.md" \
+    || fail "Documentation/CLAUDE.md lacks the @AGENTS.md import line"
+pass "generator emits @AGENTS.md import file in Documentation/"
+
+# Non-hostile scope dirs must still get symlinks.
+[ -e "$FX/src/CLAUDE.md" ] || fail "no src/CLAUDE.md generated (src scope not detected; fixture needs >=5 source files)"
+[ -L "$FX/src/CLAUDE.md" ] || fail "src/CLAUDE.md should still be a symlink"
+pass "non-hostile scope dirs still get symlinks"
+
+# --- Test 2: validator accepts the import file without a warning -------------
+out=$(bash "$VALIDATE" "$FX" 2>&1)
+if echo "$out" | grep -q "CLAUDE.md is a regular file"; then
+    fail "validate-structure.sh still warns about the @AGENTS.md import file"
+fi
+pass "validator accepts the @AGENTS.md import file"
+
+# --- Test 3: a regular CLAUDE.md without the import still warns --------------
+printf 'unrelated content\n' > "$FX/Documentation/CLAUDE.md"
+out=$(bash "$VALIDATE" "$FX" 2>&1)
+if ! echo "$out" | grep -q "CLAUDE.md is a regular file"; then
+    fail "validate-structure.sh no longer warns about a non-import regular CLAUDE.md"
+fi
+pass "non-import regular CLAUDE.md still warns"
+
+echo "All CLAUDE.md import-file regression tests passed."

--- a/skills/agent-rules/scripts/tests/test-scope-index-heading.sh
+++ b/skills/agent-rules/scripts/tests/test-scope-index-heading.sh
@@ -73,7 +73,22 @@ else
     fail "validate-structure.sh rejected the legacy scope-index heading"
 fi
 
-# --- Test 3: bloated root without any scope index still fails ----------------
+# --- Test 3: title-case heading (older generated roots) accepted (#81) -------
+TITLE_HEADING='## Index of Scoped AGENTS.md'
+FX4="$WORK/title-case-heading"
+cp -r "$FX1" "$FX4"
+# Temp file + mv keeps this portable across GNU and BSD sed (see Test 2).
+sed "s|^${NEW_HEADING}\$|${TITLE_HEADING}|" "$FX4/AGENTS.md" > "$FX4/AGENTS.md.tmp"
+mv "$FX4/AGENTS.md.tmp" "$FX4/AGENTS.md"
+grep -qF "$TITLE_HEADING" "$FX4/AGENTS.md" || fail "could not rewrite heading to title-case form"
+
+if bash "$VALIDATE" "$FX4" >/dev/null 2>&1; then
+    pass "root with title-case heading validates (#81)"
+else
+    fail "validate-structure.sh rejected the title-case scope-index heading (#81 regression)"
+fi
+
+# --- Test 4: bloated root without any scope index still fails ----------------
 FX3="$WORK/no-heading"
 cp -r "$FX1" "$FX3"
 # Drop the scope-index heading so the >50-line root has no index at all.

--- a/skills/agent-rules/scripts/validate-structure.sh
+++ b/skills/agent-rules/scripts/validate-structure.sh
@@ -9,7 +9,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # "## Scoped AGENTS.md (MUST read ...)" and the legacy "## Index of scoped
 # AGENTS.md" so validation stays in sync with generate-agents.sh output and
 # remains backward-compatible with files produced by older versions.
-SCOPE_INDEX_HEADING_RE='^## (Index of scoped|Scoped) AGENTS\.md'
+# Case-tolerant via bracket classes (not grep -i / sed I) so the same regex
+# works in grep -E and sed -E on both GNU and BSD (#81): older generated roots
+# use the title-case "## Index of Scoped AGENTS.md".
+SCOPE_INDEX_HEADING_RE='^## ([Ii]ndex of [Ss]coped|[Ss]coped) AGENTS\.md'
 
 # Default options
 PROJECT_DIR=""
@@ -129,7 +132,7 @@ check_root_is_thin() {
         success "Root has scope index (verbose style acceptable)"
         return 0
     else
-        error "Root is bloated: $line_count lines and no scope index"
+        error "Root is bloated: $line_count lines and no scope index (expected an '## Index of scoped AGENTS.md' or '## Scoped AGENTS.md ...' heading)"
         return 1
     fi
 }
@@ -260,7 +263,14 @@ check_claude_symlink() {
             return 1
         fi
     elif [ -f "$claude_file" ]; then
-        warning "CLAUDE.md is a regular file, not a symlink to AGENTS.md: $rel_dir"
+        # A regular file with an @AGENTS.md import line is fully valid: some
+        # directories cannot hold symlinks (the TYPO3 docs renderer lists
+        # Documentation/ via Flysystem, which aborts on symlinks -- #82).
+        if grep -qE '^@AGENTS\.md[[:space:]]*$' "$claude_file"; then
+            success "CLAUDE.md import file (@AGENTS.md): $rel_dir"
+            return 0
+        fi
+        warning "CLAUDE.md is a regular file, not a symlink to AGENTS.md (add an '@AGENTS.md' import line or replace with a symlink): $rel_dir"
         return 1
     else
         error "Missing CLAUDE.md symlink to AGENTS.md: $rel_dir (Claude Code won't read AGENTS.md without it)"


### PR DESCRIPTION
Closes #81. Closes #82.

**#81** — `validate-structure.sh` matched the scope-index heading case-sensitively (`grep -qE` without `-i`) while every other section check greps case-insensitively, so a title-case `## Index of Scoped AGENTS.md` root was reported as "bloated, no scope index". Fixed with bracket classes in `SCOPE_INDEX_HEADING_RE` (portable across grep and sed on GNU and BSD — the same regex feeds the `sed` link-extraction range, where flag-based case folding is GNU-only). The bloat error message now names the expected heading.

**#82** — `Documentation/` cannot hold CLAUDE.md symlinks: the TYPO3 docs renderer lists it via Flysystem, which aborts on any symbolic link (hit in netresearch/t3x-rte_ckeditor_image#888). `generate-agents.sh` now writes a regular `@AGENTS.md` import file there (Claude Code and Gemini CLI both support the import syntax); other scope dirs keep symlinks. `validate-structure.sh` accepts an import-line CLAUDE.md as fully valid and still warns on other regular files, with the warning now naming both remedies.

Also in `generate-agents.sh`, required by the shellcheck commit gate on the touched file: removed the shadowed duplicate `backend-python`/`backend-typescript` case arms (SC2221/SC2222 — the earlier scope-command-aware arms always match, so the later root-command copies were dead code) and silenced SC1091 on the three lib `source` lines (the libs are shellchecked individually by the same hook).

**Tests** — new `test-claude-import-file.sh` (generator emits import file, symlinks preserved elsewhere, validator accepts import / still warns on non-import) and a title-case case in `test-scope-index-heading.sh`, both wired into `test-scripts.yml`. Verified red-green: both new tests fail on the previous scripts and pass after the change.