### PR TITLE
fix(examples): give the two empty lock files the placeholder their siblings have

### DIFF
--- a/skills/agent-rules/references/examples/go-with-internal-web-tsx/package-lock.json
+++ b/skills/agent-rules/references/examples/go-with-internal-web-tsx/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/skills/agent-rules/references/examples/php-with-frontend/pnpm-lock.yaml
+++ b/skills/agent-rules/references/examples/php-with-frontend/pnpm-lock.yaml
@@ -1,0 +1,3 @@
+# pnpm lockfile placeholder
+# This file indicates pnpm is the package manager
+lockfileVersion: '9.0'


### PR DESCRIPTION
Two files in the example trees were committed at zero bytes: `skills/agent-rules/references/examples/go-with-internal-web-tsx/package-lock.json` and `.../php-with-frontend/pnpm-lock.yaml`.

**Why it surfaced now.** `skill-repo-skill`'s `validate.yml` is gaining a repo-wide JSON syntax check ([netresearch/skill-repo-skill#181](https://github.com/netresearch/skill-repo-skill/issues/181)). Parsing every tracked `*.json` across the 51 skill repos checked out locally found exactly one failure in the whole fleet — this file. A zero-byte file is not valid JSON.

**Deleting them would have been wrong**, which is the part worth stating: `detect-scopes.sh:227` and `extract-commands.sh:55` decide the package manager with `[ -f pnpm-lock.yaml ]` / `[ -f package-lock.json ]`. Existence is the whole signal, so removing the file changes what the example demonstrates. The sibling examples already show what belongs in one — `express-api-ts/pnpm-lock.yaml` and `fastapi-app/uv.lock` each carry a short self-describing placeholder — so both files now follow that convention instead.

Checked after the change: the JSON parses, `[ -f package-lock.json ]` still holds in the example dir, and the only remaining empty tracked files in the repo are the two intentional `.gitkeep` markers.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01CT41JfSGYEJJaBUZxg7xzu)_
