### PR TITLE
fix(agent-rules): stop validating third-party AGENTS.md in dependency trees

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -26,4 +26,4 @@ jobs:
     permissions:
       contents: read
     with:
-      check-cmd: bash skills/agent-rules/scripts/tests/test-scope-index-heading.sh && bash skills/agent-rules/scripts/tests/test-claude-import-file.sh
+      check-cmd: bash skills/agent-rules/scripts/tests/test-scope-index-heading.sh && bash skills/agent-rules/scripts/tests/test-claude-import-file.sh && bash skills/agent-rules/scripts/tests/test-dependency-tree-exclusion.sh

--- a/skills/agent-rules/scripts/tests/test-dependency-tree-exclusion.sh
+++ b/skills/agent-rules/scripts/tests/test-dependency-tree-exclusion.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Regression test for dependency-tree exclusion in validate-structure.sh (issue #84).
+#
+# The CLAUDE.md-symlink scan excludes vendor/ and node_modules/, but the scoped
+# AGENTS.md scan did not — so third-party AGENTS.md files shipped inside an
+# installed composer vendor/ tree were validated as if they were the project's
+# own, reporting their missing sections as project errors. TYPO3 extensions
+# install dependencies under .Build/vendor/, so that path must be excluded too.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(dirname "$SCRIPT_DIR")"
+VALIDATE="$SCRIPTS_DIR/validate-structure.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "❌ FAIL: $1"; exit 1; }
+pass() { echo "✅ PASS: $1"; }
+
+# A minimal project whose OWN files are valid, plus third-party AGENTS.md files
+# in the three dependency trees. Only the dependency files are non-conforming.
+FX="$WORK/proj"
+mkdir -p "$FX/vendor/acme/lib" "$FX/node_modules/pkg" "$FX/.Build/vendor/acme/ext"
+
+cat > "$FX/AGENTS.md" <<'MD'
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+
+# AGENTS.md
+
+**Precedence:** The **closest AGENTS.md** to changed files wins. Root holds global defaults only.
+
+## Index of scoped AGENTS.md
+
+- nothing scoped yet
+MD
+ln -s AGENTS.md "$FX/CLAUDE.md"
+
+for d in vendor/acme/lib node_modules/pkg .Build/vendor/acme/ext; do
+    printf '# Third-party AGENTS.md\n\nNo managed header, no required sections.\n' > "$FX/$d/AGENTS.md"
+done
+
+out=$(bash "$VALIDATE" "$FX" 2>&1); rc=$?
+
+for d in vendor node_modules .Build; do
+    if grep -q "/$d/" <<<"$out"; then
+        echo "$out" | grep "/$d/" | head -3
+        fail "validate-structure.sh scanned the $d/ dependency tree (#84)"
+    fi
+done
+pass "dependency trees (vendor, node_modules, .Build) are not scanned"
+
+if [ "$rc" -ne 0 ]; then
+    echo "$out"
+    fail "a project that is valid on its own files exited non-zero"
+fi
+pass "project with valid own files passes despite third-party AGENTS.md files"
+
+# The project's own scoped files must still be validated.
+mkdir -p "$FX/src"
+printf '# AGENTS.md -- src\n\nNo managed header, no required sections.\n' > "$FX/src/AGENTS.md"
+out=$(bash "$VALIDATE" "$FX" 2>&1)
+grep -q "src/AGENTS.md" <<<"$out" || fail "the project's own scoped AGENTS.md was skipped"
+pass "the project's own scoped files are still validated"
+
+echo "All dependency-tree exclusion tests passed."

--- a/skills/agent-rules/scripts/validate-structure.sh
+++ b/skills/agent-rules/scripts/validate-structure.sh
@@ -311,6 +311,7 @@ ALL_AGENTS_FILES=$(find "$PROJECT_DIR" -name "AGENTS.md" \
     -not -path "*/.git/*" \
     -not -path "*/vendor/*" \
     -not -path "*/node_modules/*" \
+    -not -path "*/.Build/*" \
     2>/dev/null || true)
 
 if [ -n "$ALL_AGENTS_FILES" ]; then
@@ -322,12 +323,16 @@ if [ -n "$ALL_AGENTS_FILES" ]; then
 fi
 echo ""
 
-# Check scoped AGENTS.md files (exclude reference examples)
+# Check scoped AGENTS.md files (exclude reference examples and dependency trees:
+# third-party AGENTS.md files are not the project's to fix -- #84)
 SCOPED_FILES=$(find "$PROJECT_DIR" -name "AGENTS.md" \
     -not -path "$ROOT_FILE" \
     -not -path "*/references/examples/*" \
     -not -path "*/examples/*" \
     -not -path "*/.git/*" \
+    -not -path "*/vendor/*" \
+    -not -path "*/node_modules/*" \
+    -not -path "*/.Build/*" \
     2>/dev/null || true)
 
 if [ -n "$SCOPED_FILES" ]; then


### PR DESCRIPTION
Closes #84.

The scoped-file `find` in `validate-structure.sh` excluded only `references/examples`, `examples` and `.git`, while the CLAUDE.md-symlink `find` directly above it also excluded `vendor/` and `node_modules/`. On a tree with installed composer dependencies the validator therefore walked into `vendor/` and reported missing sections in dependency-shipped AGENTS.md files as project errors — 3 false errors on netresearch/t3x-contexts (sanmai/di-container, sanmai/pipeline, overtrue/phplint), which surfaced during the t3x AGENTS.md sweep.

Both scans now exclude `vendor/`, `node_modules/` and `.Build/`. The last one matters for TYPO3 extensions, which install their dependencies under `.Build/vendor/`, and it was missing from the symlink scan too.

**Tests** — new `test-dependency-tree-exclusion.sh` builds a project whose own files are valid and plants non-conforming AGENTS.md files in all three dependency trees, then asserts none of them is scanned, that the project still exits 0, and that the project's own scoped file is still validated. Wired into `test-scripts.yml` alongside the two existing suites. Verified red-green: it fails on the previous script ("scanned the vendor/ dependency tree") and passes after the change; the two existing suites and shellcheck stay green.