### PR TITLE
chore(release): v3.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-rules",
-  "version": "3.14.1",
+  "version": "3.15.0",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "repository": "https://github.com/netresearch/agent-rules-skill",
   "license": "(MIT AND CC-BY-SA-4.0)",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-rules",
-  "version": "3.14.1",
+  "version": "3.15.0",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, jq 1.7+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.14.1"
+  version: "3.15.0"
   repository: https://github.com/netresearch/agent-rules-skill
 allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
 ---


### PR DESCRIPTION
Version bump for the v3.15.0 release. Minor, not patch: #83 changed what `generate-agents.sh` produces for `Documentation/` scopes, which is new behavior rather than a repaired one.

Since v3.14.1:

- **#83** — `validate-structure.sh` matches the scope-index heading case-insensitively (title-case roots were reported as bloated with no index), and the CLAUDE.md contract now accepts a regular `@AGENTS.md` import file; `generate-agents.sh` emits that form inside `Documentation/`, where the TYPO3 docs renderer (Flysystem) aborts on symbolic links. Also removed two shadowed dead case arms in the generator.
- **#85** — the two empty example lock files got the placeholder their siblings carry.
- **#86** — neither AGENTS.md scan walks into `vendor/`, `node_modules/` or `.Build/` any more, so dependency-shipped AGENTS.md files stop being reported as project errors.

All three shipped with red-green regression tests wired into `test-scripts.yml`.

**Test plan**

`bump-version.sh 3.15.0 --apply` wrote all three version surfaces; `check-version-parity.sh v3.15.0` passes. Tag follows the merge, per release-discipline.