### PR TITLE
docs(agent-rules): fleet sync sweep reference and the preservation check

### DIFF
--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -44,25 +44,26 @@ See `references/scripts-guide.md` for full options.
 
 ## Workflow
 
-1. **Detect**: `detect-project.sh` + `detect-scopes.sh` to identify stacks and subsystems
-2. **Extract**: `extract-commands.sh`, `extract-ci-rules.sh`, etc. to gather facts
-3. **Generate**: `generate-agents.sh` with `--style=thin` (default) or `--verbose`
+1. **Detect**: `detect-project.sh` + `detect-scopes.sh` — stacks and subsystems
+2. **Extract**: `extract-commands.sh`, `extract-ci-rules.sh` — gather facts
+3. **Generate**: `generate-agents.sh --style=thin` (default) or `--verbose`
 4. **Verify**: `verify-content.sh` + `verify-commands.sh` -- MANDATORY before done
 
-Use `--update` to preserve human-curated content outside `<!-- GENERATED -->` markers.
+`--update` preserves curated content outside `<!-- GENERATED -->` markers.
 
 ## Core Principles
 
 - **Structured over Prose** -- tables parse faster than paragraphs
 - **Never Fabricate** -- only document what exists; verify every command and path
 - **Pointer Principle** -- point to files, don't duplicate content
-- **Auto Symlinks** -- CLAUDE.md/GEMINI.md symlinks by default (see [`ai-tool-compatibility.md`](references/ai-tool-compatibility.md))
+- **Auto Symlinks** -- CLAUDE.md/GEMINI.md by default ([`ai-tool-compatibility.md`](references/ai-tool-compatibility.md))
 
 ## References
 
 | File | Contents |
 |------|----------|
-| [`verification-guide.md`](references/verification-guide.md) | Verification steps, anti-bloat |
+| [`verification-guide.md`](references/verification-guide.md) | Verification steps, anti-bloat, preservation check |
+| [`fleet-sync-sweep.md`](references/fleet-sync-sweep.md) | Fleet-wide AGENTS.md sweeps |
 | [`scripts-guide.md`](references/scripts-guide.md) | Script options, validation checklist |
 | [`quality-rubric.md`](references/quality-rubric.md) | Grading rubric |
 | [`ai-tool-compatibility.md`](references/ai-tool-compatibility.md) | 16-agent compatibility matrix |
@@ -79,7 +80,7 @@ Root: `assets/root-thin.md` (default) or `root-verbose.md`. Scoped: `assets/scop
 
 ## Supported Projects
 
-Go, PHP (Composer/Laravel/Symfony/TYPO3/Oro), TypeScript (React/Next/Vue/Node), Python (pip/poetry/ruff/mypy), Skill repos, Hybrid (auto-scoping).
+Go, PHP (Composer/Laravel/Symfony/TYPO3/Oro), TypeScript (React/Next/Vue/Node), Python (pip/poetry/ruff/mypy), skill repos, hybrid.
 
 ## See Also
 

--- a/skills/agent-rules/references/fleet-sync-sweep.md
+++ b/skills/agent-rules/references/fleet-sync-sweep.md
@@ -1,0 +1,49 @@
+# Fleet Sync Sweep
+
+Bringing AGENTS.md across a whole repo fleet to one standard, in one pass. Written after the 2026-08-19 sweep over 24 `netresearch/t3x-*` repositories (17 with existing files to sync, 5 with none at all, 2 already done) — every step below either saved that sweep or was learned by breaking it.
+
+## Shape
+
+Four phases, in this order. The expensive mistake is starting the per-repo work before the assessment exists — you then discover mid-sweep that a third of the fleet needs a different treatment.
+
+1. **Assess mechanically, all repos, before touching one.** One script that per repo fetches, resolves the default branch, creates or updates a checkout, then runs `validate-structure.sh`, `score-agents.sh` and (if the harness is in play) `verify-harness.sh`, writing one TSV row plus a per-repo log. That table is the plan: it separates the repos that need a *sync* from those that need first-time *generation*, and its before/after numbers become the report.
+2. **Write a playbook file, not a prompt.** Every trap you already know goes in one markdown file that each agent reads first. A trap explained in a prompt is explained once per agent and drifts; a playbook file is one artifact you can fix mid-sweep.
+3. **Fan out in small batches**, each agent on one repo in its own worktree.
+4. **Verify and merge in the main loop only.** Never the agent.
+
+## The playbook file
+
+It must state, at minimum: the worktree convention with absolute paths, the exact verification commands and their pass criteria, the required sections for scoped files, the CLAUDE.md convention including directories where symlinks are forbidden, commit/PR conventions (signing, conventional commits, no bot attribution, issue-before-PR where the repo demands it), and a fixed report format the agent must end with.
+
+Two clauses do the heavy lifting:
+
+- **"Never merge."** State it as the first absolute rule. An agent that merges removes your verification step entirely, and it will merge if it can.
+- **"Verify every fact you write."** Commands against `composer.json`/`Makefile`, CI claims against the workflow file, referenced paths against the tree. Documentation drift is exactly what the sweep exists to fix; an agent inventing new drift while fixing old drift is the failure mode that looks like success.
+
+## Batch size
+
+Cap concurrent agents at ~4. Larger fan-outs trip the global rate limiter, and a throttled agent fails in ways that look like content problems. Batches of four across six waves cost less wall-clock than one wave of twenty that half-fails.
+
+## Verification in the main loop
+
+The per-repo scripts are necessary and not sufficient. In the 2026-08-19 sweep all three agent errors that mattered passed `validate-structure.sh` **and** `verify-harness.sh` green:
+
+| What the agent did | What caught it |
+|---|---|
+| Deleted a curated "Response Style" section to meet the line budget | reading the diff for removed `##` headings |
+| Wrote a file count into a scoped file | the repo's own convention test, red in CI |
+| Wrote a non-conventional commit subject | reading `git log --format=%s -1` |
+
+So the main-loop pass per PR is: rerun the tools yourself (never trust the reported numbers), diff every documented command against the real `composer.json`/`Makefile`, resolve every referenced path, and for each removed heading prove where its content went — see [`verification-guide.md`](verification-guide.md). Only then merge.
+
+## Traps that cost time
+
+- **A background CI watcher dies with the worktree it was started in.** `getcwd: cannot access parent directories` after you clean up a merged repo. Start watchers from a stable directory, never from the worktree they are watching.
+- **Fast-moving repos need the rebase built into the plan.** One repo's `main` moved twice between green CI and merge; each move meant rebase, re-verify, re-watch. Arm auto-merge as soon as the gate is clean rather than after the next status read.
+- **Repo-specific tests outrank the generic rules.** One repo forbids file counts in agent docs and enforces it in its unit suite; the sweep's own "name what exists" phrasing broke it anyway. When a repo's CI red-flags generated documentation, the repo is right.
+- **A default branch is not always `main`.** Resolve it per repo (`git ls-remote --symref origin HEAD`); one `master` in the fleet breaks every hardcoded assumption at once.
+- **Local checkouts are unreliable ground truth.** Dirty, behind, or parked on someone's feature branch. Create the task worktree from `origin/<default>` and never edit the pre-existing checkout.
+
+## Reporting
+
+Report per repo: issue URL, PR URL, gate state, checks, and the before/after numbers from phase 1. A sweep summary without the assessment numbers cannot be audited; with them, "average 68 → 96" is a claim someone can re-derive.

--- a/skills/agent-rules/references/verification-guide.md
+++ b/skills/agent-rules/references/verification-guide.md
@@ -95,6 +95,26 @@ ls tests/*.py tests/**/*.py
 - **WRONG:** Using extracted command output without running it
 - **RIGHT:** Extract -> Compare -> Fix discrepancies -> Validate
 
+## The scripts verify structure, not preservation
+
+`validate-structure.sh` and `score-agents.sh` answer "does this file have the right shape", never "is the knowledge still here". An update that deletes a hard-won convention to meet the line budget passes both, and scores *higher* afterwards, because conciseness is a graded dimension and lost knowledge is not.
+
+This is not hypothetical. In a 24-repo sweep on 2026-08-19 three updates were green on every script and still wrong: one dropped a curated response-style section, one dropped an "Implementation Conventions" block distilled from five PR review cycles, one wrote a file count into a repo whose own unit test forbids exactly that. Two of the three were caught by reading the diff; the third by CI.
+
+So after any update to an existing AGENTS.md, run the preservation check by hand:
+
+```bash
+# Every heading the change removed -- each one needs an answer
+git diff <base>...HEAD -- AGENTS.md | grep -E '^-## '
+
+# For each, prove where it went (scoped file, docs/, an ADR) or that it is genuinely obsolete
+grep -rn "<distinctive phrase from the removed section>" AGENTS.md */AGENTS.md docs/
+```
+
+Relocation is the normal, correct outcome — the [pointer principle](../SKILL.md) wants detail out of the root. Deletion is legitimate when the thing described no longer exists. What is never acceptable is *unaccounted* removal, and the scripts cannot tell the three apart. A removed heading with no successor is a finding, not a diff artifact.
+
+The mirror-image failure is characterizing a deletion you have not read: a diffstat gives size, not significance. Before calling removed content a loss, read it at the parent commit (`git show <commit>^:<path>`) and check whether what it documents still exists — in the same sweep, a 105-line file that looked like a painful loss turned out to document seven workflows deleted in that very commit.
+
 ## What NOT to Put in a Root AGENTS.md
 
 The **root** AGENTS.md is auto-loaded into every session -- each line spends prompt


### PR DESCRIPTION
Two learnings from a 24-repo AGENTS.md sweep across `netresearch/t3x-*` (2026-08-19), written back into the skill.

**`references/fleet-sync-sweep.md` (new)** — the shape that worked: assess the whole fleet mechanically before touching one repo (the resulting table *is* the plan and supplies the before/after numbers), put every known trap in one playbook file rather than in each agent's prompt, fan out in batches of ~4 (larger trips the rate limiter), and verify plus merge only in the main loop. Includes the traps that cost time: watchers dying with the worktree they were started in, fast-moving default branches needing the rebase built into the plan, repo-specific tests outranking the generic rules, and a fleet member whose default branch is `master`.

**`references/verification-guide.md` (extended)** — the preservation check. `validate-structure.sh` and `score-agents.sh` answer whether a file has the right shape, never whether its knowledge survived, and an update that drops a curated section to meet the line budget passes both while scoring *higher* for conciseness. In the sweep, three such updates were green on every script: a dropped response-style section, a dropped block distilled from five PR review cycles, and a file count in a repo whose own unit test forbids exactly that. The section adds the concrete check (every removed `##` heading needs a proven successor) and names the mirror-image failure — characterizing removed content as a loss without reading it, which cost a wrong finding in the same sweep.

**Test plan**

`validate-structure.sh .` passes; `markdownlint-cli2` clean on both reference files; SKILL.md is exactly at its 500-word ceiling (four existing lines tightened to fit the new reference row — see #9 for the standing budget pressure).

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_014xvtJa2kkfAqmGDNEcrPcS)_