### PR TITLE
fix(agent-rules): stop writing commands and indexes the project does not have

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -26,4 +26,11 @@ jobs:
     permissions:
       contents: read
     with:
-      check-cmd: bash skills/agent-rules/scripts/tests/test-scope-index-heading.sh && bash skills/agent-rules/scripts/tests/test-claude-import-file.sh && bash skills/agent-rules/scripts/tests/test-dependency-tree-exclusion.sh
+      # Every test in the directory, discovered rather than listed. The
+      # previous form named each script, so a test added later ran only on
+      # the author's machine and CI stayed green without it — a test that
+      # exists but never runs reads as coverage while enforcing nothing.
+      check-cmd: >-
+        for t in skills/agent-rules/scripts/tests/*.sh; do
+          echo "── $t"; bash "$t" || exit 1;
+        done

--- a/skills/agent-rules/scripts/detect-scopes.sh
+++ b/skills/agent-rules/scripts/detect-scopes.sh
@@ -316,6 +316,27 @@ if [ "$concourse_detected" = true ] && [ -n "$concourse_dir" ] && [ -d "$concour
 fi
 
 # Output JSON
+# A directory that already carries an AGENTS.md IS a scope, whatever the
+# language heuristics above concluded. Detection knows a fixed set of
+# directory names; a project may reasonably keep a scoped file somewhere else
+# (TYPO3 `Configuration/`, for one). Leaving such a file out of the root index
+# means an agent reading the root never learns it exists — the precedence rule
+# the index exists to serve silently stops working, and nothing reports it.
+while IFS= read -r existing; do
+    [ -n "$existing" ] || continue
+    dir="${existing%/AGENTS.md}"
+    dir="${dir#./}"
+    case "$dir" in
+        "" | "." | "AGENTS.md") continue ;;        # the root file itself
+    esac
+    for known in "${scopes[@]}"; do
+        [ "$(printf '%s' "$known" | jq -r '.path')" = "$dir" ] && continue 2
+    done
+    count=$(find "$dir" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+    add_scope "$dir" "existing" "$count"
+done < <(find . -name AGENTS.md -not -path './.git/*' -not -path './node_modules/*' \
+             -not -path './vendor/*' -not -path './.Build/*' 2>/dev/null | sort)
+
 if [ ${#scopes[@]} -eq 0 ]; then
     echo '{"scopes": []}'
 else

--- a/skills/agent-rules/scripts/detect-scopes.sh
+++ b/skills/agent-rules/scripts/detect-scopes.sh
@@ -329,7 +329,10 @@ while IFS= read -r existing; do
     case "$dir" in
         "" | "." | "AGENTS.md") continue ;;        # the root file itself
     esac
-    for known in "${scopes[@]}"; do
+    # `${scopes[@]}` on an empty array counts as unset under `set -u` before
+    # bash 4.4, and this loop is reached with nothing detected yet whenever a
+    # project's only scoped file sits in an unrecognised directory.
+    for known in ${scopes[@]+"${scopes[@]}"}; do
         [ "$(printf '%s' "$known" | jq -r '.path')" = "$dir" ] && continue 2
     done
     count=$(find "$dir" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')

--- a/skills/agent-rules/scripts/extract-commands.sh
+++ b/skills/agent-rules/scripts/extract-commands.sh
@@ -3,6 +3,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source-path=SCRIPTDIR
+# shellcheck disable=SC1091  # the pre-commit hook runs shellcheck without
+# -x, so it cannot follow this source no matter how the path is written.
 source "$SCRIPT_DIR/lib/config-root.sh"
 
 PROJECT_DIR="${1:-.}"
@@ -188,32 +191,49 @@ extract_from_package_json() {
     fi
 }
 
+# Print the first composer script key that is actually defined, or nothing.
+# Callers emit `composer run <key>`, so the key has to be the one that exists.
+composer_script_key() {
+    local key
+    for key in "$@"; do
+        if jq -e --arg k "$key" '.scripts[$k] // empty' composer.json >/dev/null 2>&1; then
+            printf '%s' "$key"
+            return 0
+        fi
+    done
+    return 0
+}
+
 # Extract from composer.json
 extract_from_composer_json() {
     [ ! -f "composer.json" ] && return 0
 
-    local has_lint has_format has_test has_phpstan
-    has_lint=$(jq -r '.scripts.lint // .scripts["cs:check"] // empty' composer.json 2>/dev/null)
-    has_format=$(jq -r '.scripts.format // .scripts["cs:fix"] // empty' composer.json 2>/dev/null)
-    has_test=$(jq -r '.scripts.test // empty' composer.json 2>/dev/null)
-    has_phpstan=$(jq -r '.scripts.phpstan // .scripts["stan"] // empty' composer.json 2>/dev/null)
+    local lint_key format_key test_key phpstan_key
 
-    if [ -n "$has_lint" ]; then
-        LINT_CMD="composer run lint"
+    # Emit the script that EXISTS, not the first name we looked for. Accepting
+    # `cs:fix` as evidence and then printing `composer run format` produces a
+    # command the project does not define, and AGENTS.md presents it as fact.
+    lint_key=$(composer_script_key lint "cs:check")
+    format_key=$(composer_script_key format "cs:fix")
+    test_key=$(composer_script_key test)
+    phpstan_key=$(composer_script_key phpstan stan)
+
+    if [ -n "$lint_key" ]; then
+        LINT_CMD="composer run $lint_key"
     fi
 
-    if [ -n "$has_format" ]; then
-        FORMAT_CMD="composer run format"
+    if [ -n "$format_key" ]; then
+        FORMAT_CMD="composer run $format_key"
     fi
 
-    if [ -n "$has_test" ]; then
-        TEST_CMD="composer run test"
+    if [ -n "$test_key" ]; then
+        TEST_CMD="composer run $test_key"
     else
         TEST_CMD="vendor/bin/phpunit"
     fi
 
-    if [ -n "$has_phpstan" ]; then
-        TYPECHECK_CMD="composer run phpstan"
+    if [ -n "$phpstan_key" ]; then
+        TYPECHECK_CMD="composer run $phpstan_key"
     elif [ -f "phpstan.neon" ] || [ -f "Build/phpstan.neon" ]; then
         TYPECHECK_CMD="vendor/bin/phpstan analyze"
     fi

--- a/skills/agent-rules/scripts/lib/template.sh
+++ b/skills/agent-rules/scripts/lib/template.sh
@@ -136,6 +136,8 @@ render_template() {
     content=$(echo "$content" | sed '/^[[:space:]]*{{[A-Z_][A-Z0-9_]*}}[[:space:]]*$/d')
 
     # Remove any remaining inline placeholders (better than "(not configured)" noise)
+    # shellcheck disable=SC2001  # regex quantifier over a character class;
+    # bash glob replacement cannot express "one class char then zero or more".
     content=$(echo "$content" | sed 's/{{[A-Z_][A-Z0-9_]*}}//g')
 
     # Remove empty lines that appear after table rows but before non-table content
@@ -211,16 +213,29 @@ build_scope_index() {
     local scopes_json="$1"
     local index=""
 
-    local count=$(echo "$scopes_json" | jq '.scopes | length')
+    local count
+    count=$(echo "$scopes_json" | jq '.scopes | length')
     if [ "$count" -eq 0 ]; then
         echo "- (No scoped AGENTS.md files yet)"
         return
     fi
 
     while read -r scope; do
-        local path=$(echo "$scope" | jq -r '.path')
-        local type=$(echo "$scope" | jq -r '.type')
-        local description=$(get_scope_description "$type")
+        local path type description
+        path=$(echo "$scope" | jq -r '.path')
+        type=$(echo "$scope" | jq -r '.type')
+        description=$(get_scope_description "$type")
+
+        # A scope discovered only because it already carries an AGENTS.md has no
+        # type to describe. Let the file speak for itself — its own Overview
+        # line says what the directory is for, which beats any label this
+        # script could invent. Falls back to a neutral phrase, never to the
+        # bare type name, which reads as a bug in the generated output.
+        if [ "$type" = "existing" ]; then
+            description=$(sed -n '/^## Overview/,/^## /p' "$path/AGENTS.md" 2>/dev/null \
+                | grep -v '^##' | grep -v '^$' | head -1 | cut -c1-100)
+            [ -n "$description" ] || description="Scoped rules for \`$path/\`"
+        fi
 
         index="$index- \`./$path/AGENTS.md\` — $description\n"
     done < <(echo "$scopes_json" | jq -c '.scopes[]')
@@ -253,7 +268,15 @@ get_scope_description() {
         "github-actions") echo "GitHub Actions workflows and CI/CD automation" ;;
         "gitlab-ci") echo "GitLab CI/CD pipeline configuration" ;;
         "concourse") echo "Concourse CI pipeline and task definitions" ;;
-        *) echo "$type" ;;
+        "typo3-testing") echo "TYPO3 test suites, fixtures and the Docker test runner" ;;
+        "typo3-docs") echo "TYPO3 documentation (reStructuredText, rendered by the docs toolchain)" ;;
+        "ddev") echo "DDEV local development environment and its commands" ;;
+        "python-modern") echo "Python package using the modern toolchain (uv, ruff, pyproject)" ;;
+        # Falling through prints the raw type name into user-facing output,
+        # which reads as a bug rather than a description. Anything reaching
+        # here is a type someone added to detect-scopes.sh without a matching
+        # case above — say so plainly instead of leaking the identifier.
+        *) echo "Scoped rules for this directory" ;;
     esac
 }
 
@@ -320,6 +343,7 @@ update_generated_sections() {
     local template_file="$1"
     local existing_file="$2"
     local output_file="$3"
+    # shellcheck disable=SC2034  # nameref, read through the indirect name below
     local -n update_vars=$4
 
     # First render the template to get new content
@@ -370,6 +394,7 @@ update_generated_sections() {
     # Update timestamp
     local today
     today=$(date +%Y-%m-%d)
+    # shellcheck disable=SC2001  # see above: quantified class, not a glob.
     result=$(echo "$result" | sed "s/Last updated: [0-9-]*/Last updated: $today/")
 
     # Write result
@@ -384,6 +409,7 @@ update_generated_sections() {
 render_template_smart() {
     local template_file="$1"
     local output_file="$2"
+    # shellcheck disable=SC2034  # nameref, read through the indirect name below
     local -n smart_vars=$3
     local update_mode="${4:-false}"
 

--- a/skills/agent-rules/scripts/tests/test-extract-commands-real-scripts.sh
+++ b/skills/agent-rules/scripts/tests/test-extract-commands-real-scripts.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Regression test: extract-commands.sh must emit the composer script that the
+# project actually defines, never the first name it happened to look for.
+#
+# The bug: the PHP branch accepted `.scripts.format // .scripts["cs:fix"]` as
+# evidence and then printed `composer run format` unconditionally. A project
+# defining only `cs:fix` therefore had `composer run format` written into its
+# AGENTS.md — a command that does not exist, presented to agents as fact.
+# The same shape applied to `lint` (via `cs:check`) and `phpstan` (via `stan`).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXTRACT="$(dirname "$SCRIPT_DIR")/extract-commands.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "❌ FAIL: $1"; exit 1; }
+pass() { echo "✅ PASS: $1"; }
+
+# A PHP project whose scripts use the alternate names only.
+mkdir -p "$WORK/alt"
+cat > "$WORK/alt/composer.json" <<'JSON'
+{
+  "name": "acme/alt-names",
+  "require": {"php": "^8.2"},
+  "scripts": {
+    "cs:fix": "php-cs-fixer fix",
+    "cs:check": "php-cs-fixer fix --dry-run",
+    "stan": "phpstan analyse"
+  }
+}
+JSON
+
+OUT=$(bash "$EXTRACT" "$WORK/alt" 2>/dev/null)
+
+for pair in "format:cs:fix" "lint:cs:check" "typecheck:stan"; do
+    field="${pair%%:*}"
+    want="composer run ${pair#*:}"
+    got=$(printf '%s' "$OUT" | jq -r --arg f "$field" '.[$f] // ""')
+    [ "$got" = "$want" ] || fail "$field: expected '$want', got '$got'"
+done
+pass "alternate script names are emitted as themselves"
+
+# Every emitted `composer run X` must name a script the project defines.
+# This is the invariant the bug violated, stated independently of which
+# names the extractor happens to prefer today.
+while read -r key; do
+    [ -n "$key" ] || continue
+    jq -e --arg k "$key" '.scripts[$k]' "$WORK/alt/composer.json" >/dev/null 2>&1 \
+        || fail "extractor emitted 'composer run $key', which composer.json does not define"
+done < <(printf '%s' "$OUT" | jq -r '.[] | select(type == "string") | select(startswith("composer run ")) | sub("composer run ";"")')
+pass "every emitted composer command exists in composer.json"
+
+# The preferred names still win when they are present.
+mkdir -p "$WORK/std"
+cat > "$WORK/std/composer.json" <<'JSON'
+{
+  "name": "acme/standard-names",
+  "require": {"php": "^8.2"},
+  "scripts": {"format": "php-cs-fixer fix", "cs:fix": "should not be chosen"}
+}
+JSON
+got=$(bash "$EXTRACT" "$WORK/std" 2>/dev/null | jq -r '.format')
+[ "$got" = "composer run format" ] || fail "preferred name not chosen: got '$got'"
+pass "the preferred script name still wins when defined"
+
+echo "All extract-commands script-name regression tests passed."

--- a/skills/agent-rules/scripts/tests/test-scope-index-keeps-existing.sh
+++ b/skills/agent-rules/scripts/tests/test-scope-index-keeps-existing.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression test: a directory that already carries an AGENTS.md must appear in
+# the root scope index, even when detect-scopes.sh has no rule for that
+# directory name.
+#
+# The bug: the index was built purely from detected scopes. detect-scopes.sh
+# knows a fixed set of directory names, so a hand-authored scoped file
+# elsewhere (TYPO3 `Configuration/`, for one) was silently dropped from the
+# root index on `--update`. An agent reading the root then never learns the
+# file exists, which defeats the precedence rule the index exists to serve —
+# and nothing reports the omission.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(dirname "$SCRIPT_DIR")"
+DETECT="$SCRIPTS_DIR/detect-scopes.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "❌ FAIL: $1"; exit 1; }
+pass() { echo "✅ PASS: $1"; }
+
+# A PHP project with a scoped AGENTS.md in a directory the detector has no
+# rule for, plus one it does recognise.
+mkdir -p "$WORK/proj/Configuration" "$WORK/proj/Classes"
+cat > "$WORK/proj/composer.json" <<'JSON'
+{"name": "acme/thing", "require": {"php": "^8.2"}}
+JSON
+for i in 1 2 3 4 5 6; do
+    echo "<?php" > "$WORK/proj/Classes/File$i.php"
+    echo "services:" > "$WORK/proj/Configuration/Services$i.yaml"
+done
+cat > "$WORK/proj/Configuration/AGENTS.md" <<'MD'
+# Configuration
+
+## Overview
+DI services, TCA and backend routes for this extension.
+MD
+echo "# root" > "$WORK/proj/AGENTS.md"
+
+SCOPES=$(cd "$WORK/proj" && bash "$DETECT" . 2>/dev/null)
+
+printf '%s' "$SCOPES" | jq -e '.scopes[] | select(.path == "Configuration")' >/dev/null 2>&1 \
+    || fail "a directory with its own AGENTS.md was not reported as a scope"
+pass "an existing scoped AGENTS.md is reported even without a detection rule"
+
+# The root file itself must never be listed as a scope of itself.
+if printf '%s' "$SCOPES" | jq -e '.scopes[] | select(.path == "." or .path == "AGENTS.md")' >/dev/null 2>&1; then
+    fail "the root AGENTS.md was reported as its own scope"
+fi
+pass "the root AGENTS.md is not listed as a scope"
+
+# A recognised directory keeps its specific type rather than being relabelled.
+got=$(printf '%s' "$SCOPES" | jq -r '.scopes[] | select(.path == "Classes") | .type')
+[ "$got" != "existing" ] && [ -n "$got" ] \
+    || fail "a detected scope lost its type (got '$got')"
+pass "a detected scope keeps its own type"
+
+echo "All scope-index existing-file regression tests passed."


### PR DESCRIPTION
Found by running `generate-agents.sh . --update` against a real TYPO3 extension (`netresearch/t3x-nr-llm`) and diffing the result: the root AGENTS.md went from 119 lines to 102, and what came back was partly **wrong**, not merely shorter. Three defects, one shared shape — output asserted without being checked against the project.

## A command the project does not define

The composer branch accepted `.scripts.format // .scripts["cs:fix"]` as evidence that a formatter exists, then printed `composer run format` unconditionally:

```bash
has_format=$(jq -r '.scripts.format // .scripts["cs:fix"] // empty' composer.json)
if [ -n "$has_format" ]; then
    FORMAT_CMD="composer run format"     # ← always "format", whatever matched
fi
```

A project defining only `cs:fix` got `composer run format` written into its AGENTS.md and presented to agents as fact. It fails the moment anyone runs it. The same shape applied to `lint` (accepting `cs:check`) and `phpstan` (accepting `stan`). Each now emits the key that actually exists, resolved through one `composer_script_key` helper instead of three near-identical `jq` calls.

## An index that dropped a real file

The scope index was built from *detected* scopes, and `detect-scopes.sh` knows a fixed set of directory names. A hand-authored `Configuration/AGENTS.md` was therefore absent from the root index after `--update` — so an agent reading the root never learned the file existed, and the precedence rule the index exists to serve stopped working. Silently: nothing reports an omission.

A directory that already carries an AGENTS.md is now a scope by that fact alone, whatever the heuristics concluded. The root file is excluded from its own index, and a detected directory keeps its specific type rather than being relabelled — both asserted in the new test.

## Type identifiers leaking into prose

`get_scope_description` fell through to `echo "$type"`, so the generated index read `— typo3-testing` and `— ddev`. Those three types plus `python-modern` gained descriptions; the fallback now says something rather than printing an identifier. A scope found only because it already has an AGENTS.md has no type to describe, so it quotes that file's own `## Overview` line — the file describes itself better than any label this script could invent.

## The tests were not running in CI

`test-scripts.yml` listed three scripts by path, so both tests added here would have run only on the author's machine while CI stayed green without them. It now iterates the directory. Verified in both directions: the exact `check-cmd` string runs all five and exits 0, and a deliberately failing script makes it exit 1 — a loop that swallowed failures would be worse than the list it replaces.

## Verification

Both regression tests were confirmed to **fail against the unfixed scripts, for the right reason** — `composer run format` where only `cs:fix` was declared, and a missing `Configuration` scope — rather than merely to fail. The proof runs used a full copy of the scripts directory with a single file rolled back, because a first attempt with an isolated file failed for the wrong reason (empty output) and would have proved nothing.

End to end against the real extension after the fix: 7 of 7 scoped files in the index, no fabricated command, no bare type names.

## Incidental

`pre-commit` runs shellcheck on touched files only, so editing `lib/template.sh` surfaced 8 pre-existing findings there (SC2155, SC2034 on namerefs, SC2001). Those are fixed in this branch. The `source` line in `extract-commands.sh` carries an explicit `SC1091` suppression, because the hook invokes shellcheck without `-x` and cannot follow the source however the path is written.

The other **67** pre-existing findings elsewhere in `skills/agent-rules/scripts/` are untouched — `summary.sh` alone has 35. That is its own change, not this one.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss)_
