### PR TITLE
fix(agent-rules): apply the script-key fix to the package.json branch

### DIFF
--- a/skills/agent-rules/scripts/extract-commands.sh
+++ b/skills/agent-rules/scripts/extract-commands.sh
@@ -144,16 +144,16 @@ extract_from_package_json() {
     # Set install command based on package manager
     INSTALL_CMD="$PACKAGE_MANAGER install"
 
-    local has_typecheck has_lint has_format has_test has_build has_dev
-    has_typecheck=$(jq -r '.scripts.typecheck // .scripts["type-check"] // empty' package.json 2>/dev/null)
+    local typecheck_key has_lint has_format has_test has_build dev_key
+    typecheck_key=$(package_script_key typecheck "type-check")
     has_lint=$(jq -r '.scripts.lint // empty' package.json 2>/dev/null)
     has_format=$(jq -r '.scripts.format // empty' package.json 2>/dev/null)
     has_test=$(jq -r '.scripts.test // empty' package.json 2>/dev/null)
     has_build=$(jq -r '.scripts.build // empty' package.json 2>/dev/null)
-    has_dev=$(jq -r '.scripts.dev // .scripts.start // empty' package.json 2>/dev/null)
+    dev_key=$(package_script_key dev start)
 
-    if [ -n "$has_typecheck" ]; then
-        TYPECHECK_CMD="$pm_run typecheck"
+    if [ -n "$typecheck_key" ]; then
+        TYPECHECK_CMD="$pm_run $typecheck_key"
     else
         TYPECHECK_CMD="$pm_dlx tsc --noEmit"
     fi
@@ -186,23 +186,30 @@ extract_from_package_json() {
         BUILD_CMD="$pm_run build"
     fi
 
-    if [ -n "$has_dev" ]; then
-        DEV_CMD="$pm_run dev"
+    if [ -n "$dev_key" ]; then
+        DEV_CMD="$pm_run $dev_key"
     fi
 }
 
-# Print the first composer script key that is actually defined, or nothing.
-# Callers emit `composer run <key>`, so the key has to be the one that exists.
-composer_script_key() {
+# Print the first script key that the given manifest actually defines, or
+# nothing. Callers emit `<runner> <key>`, so the key has to be the one that
+# exists — accepting `cs:fix` as evidence and then printing `format` writes a
+# command the project does not have.
+manifest_script_key() {
+    local manifest="$1"
+    shift
     local key
     for key in "$@"; do
-        if jq -e --arg k "$key" '.scripts[$k] // empty' composer.json >/dev/null 2>&1; then
+        if jq -e --arg k "$key" '.scripts[$k] // empty' "$manifest" >/dev/null 2>&1; then
             printf '%s' "$key"
             return 0
         fi
     done
     return 0
 }
+
+composer_script_key() { manifest_script_key composer.json "$@"; }
+package_script_key() { manifest_script_key package.json "$@"; }
 
 # Extract from composer.json
 extract_from_composer_json() {

--- a/skills/agent-rules/scripts/tests/test-extract-commands-real-scripts.sh
+++ b/skills/agent-rules/scripts/tests/test-extract-commands-real-scripts.sh
@@ -65,4 +65,39 @@ got=$(bash "$EXTRACT" "$WORK/std" 2>/dev/null | jq -r '.format')
 [ "$got" = "composer run format" ] || fail "preferred name not chosen: got '$got'"
 pass "the preferred script name still wins when defined"
 
+# The same defect shape lived in the package.json branch: `typecheck` was
+# accepted via `type-check`, and `dev` via `start`, while the emitted command
+# always used the first name.
+mkdir -p "$WORK/npm"
+cat > "$WORK/npm/package.json" <<'JSON'
+{
+  "name": "acme-alt",
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "start": "vite",
+    "lint": "eslint ."
+  }
+}
+JSON
+
+NPM_OUT=$(bash "$EXTRACT" "$WORK/npm" 2>/dev/null)
+
+for pair in "typecheck:type-check" "dev:start"; do
+    field="${pair%%:*}"
+    want="npm run ${pair#*:}"
+    got=$(printf '%s' "$NPM_OUT" | jq -r --arg f "$field" '.[$f] // ""')
+    [ "$got" = "$want" ] || fail "$field: expected '$want', got '$got'"
+done
+pass "alternate package.json script names are emitted as themselves"
+
+# Same invariant as for composer, stated for the npm runner: an emitted
+# `<pm> run X` must name a script package.json defines. Commands that are not
+# script invocations (npx/tsc/eslint fallbacks) are out of scope here.
+while read -r key; do
+    [ -n "$key" ] || continue
+    jq -e --arg k "$key" '.scripts[$k]' "$WORK/npm/package.json" >/dev/null 2>&1 \
+        || fail "extractor emitted 'npm run $key', which package.json does not define"
+done < <(printf '%s' "$NPM_OUT" | jq -r '.[] | select(type == "string") | select(startswith("npm run ")) | sub("npm run ";"")')
+pass "every emitted npm script command exists in package.json"
+
 echo "All extract-commands script-name regression tests passed."


### PR DESCRIPTION
[#91](https://github.com/netresearch/agent-rules-skill/pull/91) fixed the composer branch and closed with an explicit gap: the sibling branches were not audited. They are now, and the npm branch carried the same defect twice.

## The defect

```bash
has_typecheck=$(jq -r '.scripts.typecheck // .scripts["type-check"] // empty' package.json)
has_dev=$(jq -r '.scripts.dev // .scripts.start // empty' package.json)
...
TYPECHECK_CMD="$pm_run typecheck"     # ← always "typecheck"
DEV_CMD="$pm_run dev"                 # ← always "dev"
```

A project defining `"type-check"` and `"start"` — an ordinary Vite/TypeScript shape — got `npm run typecheck` and `npm run dev` written into its AGENTS.md. Neither exists. Measured against a fixture with exactly those scripts:

| | before | after |
|---|---|---|
| `typecheck` | `npm run typecheck` | `npm run type-check` |
| `dev` | `npm run dev` | `npm run start` |

## The audit that closes the class

Worth stating in full, because the value here is knowing the file is done rather than one more spot being patched:

- **Makefile** — already correct. It emits `make $target` using the name it matched, which is the pattern this fix adopts everywhere else.
- **pyproject** — emits fixed tool invocations (`ruff check .`, `black .`) and looks up no script names, so no mismatch is possible.
- **package.json, remaining keys** (`lint`, `format`, `test`, `build`) — single-key lookups that emit the same key they searched for.
- **composer** — [#91](https://github.com/netresearch/agent-rules-skill/pull/91).

Nothing else in the file reads a script map.

## Shape of the fix

The resolver from #91 became one `manifest_script_key` taking the manifest path, with `composer_script_key` and `package_script_key` as thin wrappers — rather than a second near-copy for the second manifest, which is how the original defect came to exist in two places.

## Verification

The regression test gained the npm case plus the same invariant stated for the npm runner: every emitted `npm run X` must name a script `package.json` defines, independent of which names the code prefers today. Confirmed to fail against the unfixed script for the right reason (`npm run typecheck` where only `type-check` exists), using a full copy of the scripts directory with one file rolled back.

All five test scripts pass; shellcheck reports nothing on the changed file.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss)_
