### PR TITLE
chore(release): 3.15.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "agent-rules",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
-  "repository": "https://github.com/netresearch/agent-rules-skill",
-  "license": "(MIT AND CC-BY-SA-4.0)",
   "author": {
     "name": "Netresearch DTT GmbH",
     "url": "https://www.netresearch.de"
   },
+  "repository": "https://github.com/netresearch/agent-rules-skill",
+  "license": "(MIT AND CC-BY-SA-4.0)",
   "skills": [
     "./skills/agent-rules"
   ]

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-rules",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "Generate and maintain AGENTS.md, copilot-instructions.md, and other agent rule files",
   "author": {
     "name": "Netresearch DTT GmbH",

--- a/skills/agent-rules/SKILL.md
+++ b/skills/agent-rules/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, jq 1.7+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.15.0"
+  version: "3.15.1"
   repository: https://github.com/netresearch/agent-rules-skill
 allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
 ---


### PR DESCRIPTION
Version bump only. The tag follows once this merges — tagging first would release the old code.

## Why now

Four changes have been sitting on `main` unreleased, and two are defects that actively mislead rather than merely lag:

- `generate-agents.sh --update` wrote commands the target project does not define — `composer run format` where only `cs:fix` exists ([#91](https://github.com/netresearch/agent-rules-skill/pull/91)), `npm run typecheck` where only `type-check` does ([#92](https://github.com/netresearch/agent-rules-skill/pull/92)). An agent following the generated AGENTS.md runs a command that fails.
- The same `--update` dropped a hand-authored scoped `AGENTS.md` from the root index whenever its directory was not one the heuristics recognise, so the precedence rule the index exists to serve stopped working silently.

Consumers install from the tag. `main` and the installed plugin cache both sat at 3.15.0, which was cut *before* either fix, so until this releases everyone keeps running the version that does the above.

## Scope of the release

| PR | Kind |
|---|---|
| [#92](https://github.com/netresearch/agent-rules-skill/pull/92) | fix — npm script-key mismatch |
| [#91](https://github.com/netresearch/agent-rules-skill/pull/91) | fix — composer script-key mismatch, dropped scope-index entry, type names leaking into prose, CI not running new tests |
| [#90](https://github.com/netresearch/agent-rules-skill/pull/90) | docs — fleet sync sweep reference |
| [#89](https://github.com/netresearch/agent-rules-skill/pull/89) | test — evals migration |

**Patch, not minor.** Two fixes, a reference document and a test migration. Nothing new is offered, so nothing new is promised. The generated output does change for projects that were hit by the bugs — an index entry appears, a command becomes correct — but that is the defect being repaired, not a feature.

## How it was applied

`bump-version.sh` across all three version surfaces rather than by hand, then `sync-plugin-manifest.sh` to regenerate `.claude-plugin/plugin.json`, then `check-version-parity.sh` to confirm `plugin.json` and `SKILL.md` agree at 3.15.1.

The regenerated manifest also moves `repository` and `license` after `author` — the committed file had drifted from the generator's canonical ordering. That is included rather than reverted, since the point of a generated file is to match its generator.

`validate-skill.sh` reports 0 errors (9 pre-existing warnings, unchanged), and all five script regression tests pass.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_015QXXkquh2eQNBiTYA39Wss)_
